### PR TITLE
Point Source + Elliptical Obscur. + Biconic Surf.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRC_FILES
   src/quadric.cpp
   src/rayVector.cpp
   src/sphere.cpp
+  src/biconic.cpp
   src/sum.cpp
   src/surface.cpp
   src/tilted.cpp
@@ -59,6 +60,7 @@ set(PYSRC_FILES
   pysrc/quadric.cpp
   pysrc/rayVector.cpp
   pysrc/sphere.cpp
+  pysrc/biconic.cpp
   pysrc/sum.cpp
   pysrc/surface.cpp
   pysrc/tilted.cpp

--- a/batoid/__init__.py
+++ b/batoid/__init__.py
@@ -6,8 +6,8 @@ from .coordSys import CoordSys, RotX, RotY, RotZ
 from .coordTransform import CoordTransform
 
 from .surface import (
-    Surface, Plane, Paraboloid, Sphere, Quadric, Asphere, Bicubic, Sum, Tilted,
-    Zernike
+    Surface, Plane, Paraboloid, Sphere, Quadric, Asphere, Biconic,
+    Bicubic, Sum, Tilted, Zernike
 )
 
 from .trace import (
@@ -20,8 +20,8 @@ from .medium import (
 )
 
 from .obscuration import (
-    Obscuration, ObscCircle, ObscAnnulus, ObscRectangle, ObscRay, ObscPolygon,
-    ObscNegation, ObscUnion, ObscIntersection
+    Obscuration, ObscCircle, ObscEllipse, ObscAnnulus, ObscRectangle,
+    ObscRay, ObscPolygon, ObscNegation, ObscUnion, ObscIntersection
 )
 
 from .coating import Coating, SimpleCoating

--- a/batoid/obscuration.py
+++ b/batoid/obscuration.py
@@ -86,7 +86,52 @@ class ObscCircle(Obscuration):
             out += f", {self.x}, {self.y}"
         out += ")"
         return out
+    
+class ObscEllipse(Obscuration):
+    """An elliptical obscuration.
 
+    Parameters
+    ----------
+    semi_major : float
+        Semi-major axis of the ellipse in meters.
+    semi_minor : float
+        Semi-minor axis of the ellipse in meters.
+    x, y : float, optional
+        Coordinates of ellipse center in meters.  [default: 0.0]
+    """
+    def __init__(self, semi_major, semi_minor, x=0.0, y=0.0):
+        self.semi_major = semi_major
+        self.semi_minor = semi_minor
+        self.x = x
+        self.y = y
+        self._obsc = _batoid.CPPObscEllipse(semi_major, semi_minor, x, y)
+
+    def __eq__(self, rhs):
+        if type(rhs) == type(self):
+            return (
+                self.semi_major == rhs.semi_major
+                and self.semi_minor == rhs.semi_minor
+                and self.x == rhs.x
+                and self.y == rhs.y
+            )
+        return False
+
+    def __getstate__(self):
+        return self.semi_major, self.semi_minor, self.x, self.y
+
+    def __setstate__(self, args):
+        self.semi_major, self.semi_minor, self.x, self.y = args
+        self._obsc = _batoid.CPPObscEllipse(*args)
+
+    def __hash__(self):
+        return hash(("batoid.ObscEllipse", self.semi_major, self.semi_minor, self.x, self.y))
+
+    def __repr__(self):
+        out = f"ObscEllipse({self.semi_major}, {self.semi_minor}"
+        if self.x != 0 or self.y != 0:
+            out += f", {self.x}, {self.y}"
+        out += ")"
+        return out
 
 class ObscAnnulus(Obscuration):
     """An annular obscuration.

--- a/batoid/parse.py
+++ b/batoid/parse.py
@@ -6,7 +6,7 @@ import numpy as np
 def parse_obscuration(config):
     typ = config.pop('type')
     if typ in [
-        'ObscCircle', 'ObscAnnulus', 'ObscRay', 'ObscRectangle', 'ObscPolygon'
+        'ObscCircle', 'ObscAnnulus', 'ObscEllipse', 'ObscRay', 'ObscRectangle', 'ObscPolygon'
     ]:
         evalstr = "batoid.{}(**config)".format(typ)
         return eval(evalstr)

--- a/batoid/rayVector.py
+++ b/batoid/rayVector.py
@@ -7,7 +7,7 @@ from . import _batoid
 from .constants import globalCoordSys, vacuum
 from .coordTransform import CoordTransform
 from .trace import applyForwardTransform, applyForwardTransformArrays
-from .utils import fieldToDirCos, hexapolar
+from .utils import fieldToDirCos, pointSourceToDirCos, hexapolar
 from .surface import Plane
 
 
@@ -435,6 +435,14 @@ class RayVector:
         z = stopSurface.surface.sag(x, y)
         transform = CoordTransform(stopSurface.coordSys, coordSys)
         applyForwardTransformArrays(transform, x, y, z)
+
+        if dirCos is None and source is not None: # Convert source from stopSurface coordinate system to choosen one
+            x_s, y_s, z_s = np.atleast_1d(source[0]).astype(float, copy=False), np.atleast_1d(source[1]).astype(float, copy=False), np.atleast_1d(source[2]).astype(float, copy=False)
+            applyForwardTransformArrays(transform, x_s, y_s, z_s)
+            x_s, y_s, z_s = x_s[0], y_s[0], z_s[0]
+            source = np.array([x_s, y_s, z_s])
+            dirCos = pointSourceToDirCos(source, np.vstack([x, y, z]))
+
         w = np.empty_like(x)
         w.fill(wavelength)
         n = medium.getN(wavelength)
@@ -634,6 +642,14 @@ class RayVector:
         z = stopSurface.surface.sag(x, y)
         transform = CoordTransform(stopSurface.coordSys, coordSys)
         applyForwardTransformArrays(transform, x, y, z)
+
+        if dirCos is None and source is not None: # Convert source from stopSurface coordinate system to choosen one
+            x_s, y_s, z_s = np.atleast_1d(source[0]).astype(float, copy=False), np.atleast_1d(source[1]).astype(float, copy=False), np.atleast_1d(source[2]).astype(float, copy=False)
+            applyForwardTransformArrays(transform, x_s, y_s, z_s)
+            x_s, y_s, z_s = x_s[0], y_s[0], z_s[0]
+            source = np.array([x_s, y_s, z_s])
+            dirCos = pointSourceToDirCos(source, np.vstack([x, y, z]))
+        
         w = np.empty_like(x)
         w.fill(wavelength)
         n = medium.getN(wavelength)
@@ -806,6 +822,14 @@ class RayVector:
         z = stopSurface.surface.sag(x, y)
         transform = CoordTransform(stopSurface.coordSys, coordSys)
         applyForwardTransformArrays(transform, x, y, z)
+
+        if dirCos is None and source is not None: # Convert source from stopSurface coordinate system to choosen one
+            x_s, y_s, z_s = np.atleast_1d(source[0]).astype(float, copy=False), np.atleast_1d(source[1]).astype(float, copy=False), np.atleast_1d(source[2]).astype(float, copy=False)
+            applyForwardTransformArrays(transform, x_s, y_s, z_s)
+            x_s, y_s, z_s = x_s[0], y_s[0], z_s[0]
+            source = np.array([x_s, y_s, z_s])
+            dirCos = pointSourceToDirCos(source, np.vstack([x, y, z]))
+
         w = np.empty_like(x)
         w.fill(wavelength)
         n = medium.getN(wavelength)
@@ -814,48 +838,128 @@ class RayVector:
         )
 
     @classmethod
-    def _finish(
-        cls, backDist, source, dirCos, n, x, y, z, w, flux, coordSys
-    ):
-        """Map rays backwards to their source position."""
+    def _finish(cls, backDist, source, dirCos, n, x, y, z, w, flux, coordSys):
+        """Map rays backwards to their source position.
+        
+        Uses `finishParallel` for a ** single direction cosine ** (dirCos shape (3,)) => beam from infinity
+        Uses `finishParallelMultiple` for ** multiple direction cosines ** (dirCos shape (3, N)) => beam from point source
+        """
+
+        # Ensure `flux` is a NumPy array
         if isinstance(flux, Real):
             flux = np.full(len(x), float(flux))
+
         if source is None:
-            vv = np.array(dirCos, dtype=float, copy=True)
-            vv /= n*np.sqrt(np.dot(vv, vv))
-            zhat = -n*vv
-            xhat = np.cross(np.array([1.0, 0.0, 0.0]), zhat)
-            xhat /= np.sqrt(np.dot(xhat, xhat))
-            yhat = np.cross(xhat, zhat)
-            origin = zhat*backDist
-            rot = np.stack([xhat, yhat, zhat]).T
-            _batoid.finishParallel(
-                origin, rot.ravel(), vv,
-                x.ctypes.data, y.ctypes.data, z.ctypes.data,
-                len(x)
-            )
-            vx = np.full_like(x, vv[0])
-            vy = np.full_like(y, vv[1])
-            vz = np.full_like(z, vv[2])
+            vv = np.asarray(dirCos, dtype=float)  # Ensure `vv` is a NumPy array
+
+            # Check if `dirCos` is a single ray or multiple rays
+            if vv.ndim == 1:  # **Single DirCos case (3,)** => handle beam from infinity
+                # Normalize `vv`
+                norm_vv = np.linalg.norm(vv)
+                if norm_vv > 0:
+                    vv = (vv / norm_vv) * n
+
+                # Compute coordinate system transformation
+                zhat = -n * vv  # Shape (3,)
+
+                # Compute `xhat` and `yhat` using cross products
+                x_ref = np.array([1.0, 0.0, 0.0])
+                xhat = np.cross(x_ref, zhat)  # Shape (3,)
+                xhat /= np.linalg.norm(xhat)  # Normalize `xhat`
+                yhat = np.cross(xhat, zhat)  # Compute `yhat` using cross product
+
+                # Compute origin
+                origin = (zhat * backDist).tolist()  # Convert to (3,)
+
+                # Compute rotation matrix
+                rotation = np.stack([xhat, yhat, zhat]).T.flatten().tolist()  # Convert (3,3) → (9,)
+
+                # Call `finishParallel` for a single direction cosine vector
+                _batoid.finishParallel(
+                    origin, rotation, vv.tolist(),
+                    int(x.ctypes.data), int(y.ctypes.data), int(z.ctypes.data),
+                    int(len(x))
+                )
+
+            else:  # **Multiple DirCos case (3, N)** => handle beam with one DirCos per ray (same as having a source: to avoid errors)
+                num_rays = vv.shape[1]  # Get number of rays (N)
+
+                origins, rotations_list, vv_list = cls._defintions(backDist, vv, n)
+
+                # Call `finishParallelMultiple` for a multiple direction cosine vector
+                _batoid.finishParallelMultiple(
+                    origins, rotations_list, vv_list,
+                    int(x.ctypes.data), int(y.ctypes.data), int(z.ctypes.data),
+                    int(len(x))
+                )
+
+            # Assign velocity components **only once** (avoids redundant writes)
+            vx, vy, vz = vv[:, -1] if vv.ndim > 1 else vv  # Use last ray's velocity (or single ray)
+
+            # Initialize other required variables
             t = np.zeros(len(x), dtype=float)
             vignetted = np.zeros(len(x), dtype=bool)
             failed = np.zeros(len(x), dtype=bool)
+
             return RayVector._directInit(
-                x, y, z, vx, vy, vz, t, w,
-                flux, vignetted, failed, coordSys
+                x, y, z, np.full_like(x, vx), np.full_like(y, vy), np.full_like(z, vz),
+                t, w, flux, vignetted, failed, coordSys
             )
         else:
-            pass
-            # v = np.copy(r)
-            # v -= source
-            # v /= n*np.einsum('ab,ab->b', v, v)
-            # r[:] = source
-            # t = np.zeros(len(r), dtype=float)
-            # vignetted = np.zeros(len(r), dtype=bool)
-            # failed = np.zeros(len(r), dtype=bool)
-            # return RayVector._directInit(
-            #     r, v, t, w, flux, vignetted, failed, coordSys
-            # )
+            vv = np.asarray(dirCos, dtype=float)  # Ensure `vv` is a NumPy array
+
+            origins, rotations_list, vv_list = cls._defintions(backDist, vv, n)
+
+            # Call `finishParallelMultiple` for a multiple direction cosine vector
+            _batoid.finishParallelMultiple(
+                origins, rotations_list, vv_list,
+                int(x.ctypes.data), int(y.ctypes.data), int(z.ctypes.data),
+                int(len(x))
+            )
+
+            # Assign velocity components **only once** (avoids redundant writes)
+            vx, vy, vz = vv[:, -1] if vv.ndim > 1 else vv  # Use last ray's velocity (or single ray)
+
+            # Initialize other required variables
+            t = np.zeros(len(x), dtype=float)
+            vignetted = np.zeros(len(x), dtype=bool)
+            failed = np.zeros(len(x), dtype=bool)
+
+            return RayVector._directInit(
+                x, y, z, np.full_like(x, vx), np.full_like(y, vy), np.full_like(z, vz),
+                t, w, flux, vignetted, failed, coordSys
+            )
+        
+    @classmethod
+    def _defintions(cls,
+                    backDist, vv, n
+                    ):
+        num_rays = vv.shape[1]  # Get number of rays (N)
+
+        # Normalize `vv`
+        norm_vv = np.linalg.norm(vv, axis=0, keepdims=True)  # Shape: (1, N)
+        vv /= np.where(norm_vv > 0, n * norm_vv, 1)  # Avoid division by zero
+
+        # Compute coordinate system transformation
+        zhat = -n * vv  # Shape (3, N)
+
+        # Compute `xhat` and `yhat` using cross products
+        x_ref = np.array([[1.0], [0.0], [0.0]]) if num_rays > 1 else np.array([1.0, 0.0, 0.0])
+        xhat = np.cross(x_ref, zhat, axis=0)  # Shape (3, N)
+        xhat /= np.linalg.norm(xhat, axis=0, keepdims=True)  # Normalize `xhat`
+        yhat = np.cross(xhat, zhat, axis=0)  # Compute `yhat` using cross product
+
+        # Compute origins
+        origins = (zhat * backDist).T.ravel().tolist()  # Flatten to (N * 3)
+
+        # Precompute rotation matrices
+        rotations = np.stack([xhat, yhat, zhat], axis=1)  # Shape (3,3,N)
+        rotations_list = rotations.transpose(2, 0, 1).reshape(num_rays, 9).ravel().tolist()  # Flatten to (N * 9)
+
+        # Convert vv to (N * 3) flattened list
+        vv_list = vv.T.ravel().tolist()  # (3, N) → (N * 3)
+
+        return origins, rotations_list, vv_list
 
     @classmethod
     def fromStop(
@@ -972,6 +1076,13 @@ class RayVector:
         z = stopSurface.surface.sag(x, y)
         transform = CoordTransform(stopSurface.coordSys, coordSys)
         applyForwardTransformArrays(transform, x, y, z)
+
+        if dirCos is None and source is not None: # Convert source from stopSurface coordinate system to choosen one
+            x_s, y_s, z_s = np.atleast_1d(source[0]).astype(float, copy=False), np.atleast_1d(source[1]).astype(float, copy=False), np.atleast_1d(source[2]).astype(float, copy=False)
+            applyForwardTransformArrays(transform, x_s, y_s, z_s)
+            x_s, y_s, z_s = x_s[0], y_s[0], z_s[0]
+            source = np.array([x_s, y_s, z_s])
+            dirCos = pointSourceToDirCos(source, np.vstack([x, y, z]))
 
         w = np.empty_like(x)
         w.fill(wavelength)

--- a/batoid/surface.py
+++ b/batoid/surface.py
@@ -428,6 +428,63 @@ class Asphere(Surface):
         else:
             out += f", imin={self.imin})"
         return out
+    
+class Biconic(Surface):
+    """Biconic surface where the curvature and conic constant can be different 
+    along the x and y axes. The surface sag follows the equation:
+
+    .. math::
+
+        z(x, y) = \\frac{c_x x^2}{1 + \\sqrt{1 - (1 + k_x) c_x^2 x^2}} + 
+                  \\frac{c_y y^2}{1 + \\sqrt{1 - (1 + k_y) c_y^2 y^2}}
+
+    where:
+
+    - :math:`c_x = \\frac{1}{R_x}` is the curvature along the X-axis.
+    - :math:`c_y = \\frac{1}{R_y}` is the curvature along the Y-axis.
+    - :math:`k_x` and :math:`k_y` are the conic constants in the X and Y directions.
+
+    Different ranges of :math:`k_x` and :math:`k_y` indicate different categories 
+    of surfaces in each axis.
+
+    Parameters
+    ----------
+    Rx : float
+        Radius of curvature in the x-direction.
+    Ry : float
+        Radius of curvature in the y-direction.
+    kx : float
+        Conic constant in the x-direction.
+    ky : float
+        Conic constant in the y-direction.
+    """
+
+    def __init__(self, Rx, Ry, kx, ky):
+        self.Rx = Rx
+        self.Ry = Ry
+        self.kx = kx
+        self.ky = ky
+        self._surface = _batoid.CPPBiconic(Rx, Ry, kx, ky)
+
+    def __hash__(self):
+        return hash(("batoid.Biconic", self.Rx, self.Ry, self.kx, self.ky))
+
+    def __setstate__(self, args):
+        self.__init__(*args)
+
+    def __getstate__(self):
+        return (self.Rx, self.Ry, self.kx, self.ky)
+
+    def __eq__(self, rhs):
+        if not isinstance(rhs, Biconic):
+            return False
+        return (self.Rx == rhs.Rx and
+                self.Ry == rhs.Ry and
+                self.kx == rhs.kx and
+                self.ky == rhs.ky)
+
+    def __repr__(self):
+        return f"Biconic({self.Rx}, {self.Ry}, {self.kx}, {self.ky})"
 
 
 class Zernike(Surface):

--- a/batoid/utils.py
+++ b/batoid/utils.py
@@ -441,6 +441,44 @@ def fieldToDirCos(u, v, projection='postel'):
         return orthographicToDirCos(u, v)
     else:
         raise ValueError("Bad projection: {}".format(projection))
+    
+def pointSourceToDirCos(p1, p2_list):
+    """
+    Compute the direction cosines from a single point p1 to multiple points in p2_list.
+
+    Parameters:
+        p1 (array-like): A 3-element array [x, y, z] representing a single point source.
+        p2_list (array-like or np.ndarray): Either:
+            - A (3,) or (3, 1) array representing a single point [x, y, z] or [[x], [y], [z]]
+            - A (3, N) array where each row is [x_list, y_list, z_list]
+
+    Returns:
+        numpy.ndarray: A (3, N) array of unit direction vectors, or (3, 1) if p2_list is a single point.
+    """
+    p1 = np.asarray(p1)  # Convert to NumPy array
+    p2_list = np.asarray(p2_list)  # Convert p2_list to a NumPy array
+
+    # If p2_list is a single point (1D array), reshape to (3,1) for correct broadcasting
+    if p2_list.shape == (3,):
+        p2_list = p2_list[:, np.newaxis]  # Reshape to (3,1) so broadcasting works
+
+    # Ensure p2_list is in (3, N) format
+    if p2_list.shape[0] != 3:
+        raise ValueError("p2_list must have shape (3,) or (3, 1) for a single point or (3, N) for multiple points.")
+
+    # Compute direction vectors (vectorized)
+    dirVecs = p2_list - p1[:, np.newaxis]  # Shape: (3, N)
+
+    # Compute magnitudes along each column
+    mags = np.linalg.norm(dirVecs, axis=0, keepdims=True)  # Shape: (1, N)
+
+    if np.any(mags == 0):
+        raise ValueError("At least one point in p2_list is identical to p1; direction cosines cannot be determined.")
+
+    # Normalize direction vectors correctly
+    result = dirVecs / mags  # Shape remains (3, N)
+
+    return result
 
 
 def dirCosToField(alpha, beta, gamma, projection='postel'):

--- a/include/batoid.h
+++ b/include/batoid.h
@@ -1,6 +1,7 @@
 #ifndef batoid_batoid_h
 #define batoid_batoid_h
 
+#include <vector>
 #include <array>
 #include "rayVector.h"
 #include "surface.h"

--- a/include/batoid.h
+++ b/include/batoid.h
@@ -53,6 +53,14 @@ namespace batoid {
     );
 
     void finishParallel(const vec3 dr, const mat3 drot, const vec3 vv, double* x, double* y, double* z, size_t n);
+    
+    void finishParallelMultiple(
+        const std::vector<double>& origins,   // (N * 3) Flattened array
+        const std::vector<double>& rotations, // (N * 9) Flattened array
+        const std::vector<double>& vv_list,   // (N * 3) Flattened array
+        double* x, double* y, double* z,
+        size_t n
+    );
 }
 
 #endif

--- a/include/biconic.h
+++ b/include/biconic.h
@@ -1,0 +1,44 @@
+#ifndef batoid_biconic_h
+#define batoid_biconic_h
+
+#include "surface.h"
+#include "sphere.h"
+
+namespace batoid {
+
+    #if defined(BATOID_GPU)
+        #pragma omp declare target
+    #endif
+
+    class Biconic : public Surface {
+    public:
+        Biconic(double Rx, double Ry, double kx, double ky);
+        ~Biconic();
+
+        virtual const Surface* getDevPtr() const override;
+
+        virtual double sag(double x, double y) const override;
+        virtual void normal(
+            double x, double y,
+            double& nx, double& ny, double& nz
+        ) const override;
+        virtual bool timeToIntersect(
+            double x, double y, double z,
+            double vx, double vy, double vz,
+            double& dt, int niter
+        ) const override;
+
+    private:
+        const double _Rx, _Ry;  // Radii of curvature in x and y
+        const double _kx, _ky;  // Conic constants in x and y
+        const double _cx, _cy;  // Curvature (1/R)
+
+        mutable const Surface* _devPtr = nullptr;
+    };
+
+    #if defined(BATOID_GPU)
+        #pragma omp end declare target
+    #endif
+
+}
+#endif

--- a/include/obscuration.h
+++ b/include/obscuration.h
@@ -41,6 +41,19 @@ namespace batoid {
         const double _radius, _x0, _y0;
     };
 
+    class ObscEllipse : public Obscuration {
+    public:
+        ObscEllipse(double semi_major, double semi_minor, double x0=0.0, double y0=0.0);
+        ~ObscEllipse();
+
+        bool contains(double x, double y) const override;
+
+        const Obscuration* getDevPtr() const override;
+
+    private:
+        const double _semi_major, _semi_minor, _x0, _y0;
+    };
+
 
     class ObscAnnulus : public Obscuration {
     public:

--- a/pysrc/batoid.cpp
+++ b/pysrc/batoid.cpp
@@ -1,6 +1,8 @@
 #include "batoid.h"
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <vector>
+#include <cstddef>
 
 #if defined(_OPENMP)
 #include "omp.h"
@@ -16,6 +18,7 @@ namespace batoid {
     void pyExportSurface(py::module&);
     void pyExportQuadric(py::module&);
     void pyExportAsphere(py::module&);
+    void pyExportBiconic(py::module&);
     void pyExportTilted(py::module&);
     void pyExportBicubic(py::module&);
     void pyExportSphere(py::module&);
@@ -39,6 +42,7 @@ namespace batoid {
         pyExportTilted(m);
         pyExportBicubic(m);
         pyExportSphere(m);
+        pyExportBiconic(m); // Order Surface, Sphere, Biconic important b/c inheritance
         pyExportSum(m);
         pyExportParaboloid(m);
         pyExportPlane(m);
@@ -113,6 +117,22 @@ namespace batoid {
             ){
                 finishParallel(
                     dr, drot, vv,
+                    reinterpret_cast<double*>(x),
+                    reinterpret_cast<double*>(y),
+                    reinterpret_cast<double*>(z),
+                    n
+                );
+            });
+        m.def(
+            "finishParallelMultiple",
+            [](
+                const std::vector<double>& origins,   // Flattened (N * 3)
+                const std::vector<double>& rotations, // Flattened (N * 9)
+                const std::vector<double>& vv_list,   // Flattened (N * 3)
+                size_t x, size_t y, size_t z, size_t n
+            ){
+                finishParallelMultiple(
+                    origins, rotations, vv_list,
                     reinterpret_cast<double*>(x),
                     reinterpret_cast<double*>(y),
                     reinterpret_cast<double*>(z),

--- a/pysrc/biconic.cpp
+++ b/pysrc/biconic.cpp
@@ -1,0 +1,14 @@
+#include "biconic.h"
+#include <memory>
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+namespace batoid {
+    void pyExportBiconic(py::module& m) {
+        py::class_<Biconic, std::shared_ptr<Biconic>, Surface>(m, "CPPBiconic")
+            .def(py::init<double, double, double, double>(), "init", 
+                 "Rx"_a, "Ry"_a, "kx"_a, "ky"_a);
+    }
+}

--- a/pysrc/obscuration.cpp
+++ b/pysrc/obscuration.cpp
@@ -18,6 +18,10 @@ namespace batoid {
             .def(py::init<double,double,double>());
 
 
+        py::class_<ObscEllipse, std::shared_ptr<ObscEllipse>, Obscuration>(m, "CPPObscEllipse")
+            .def(py::init<double, double, double, double>());
+
+
         py::class_<ObscAnnulus, std::shared_ptr<ObscAnnulus>, Obscuration>(m, "CPPObscAnnulus")
             .def(py::init<double,double,double,double>());
 

--- a/src/batoid.cpp
+++ b/src/batoid.cpp
@@ -1,6 +1,8 @@
 #include "batoid.h"
 #include <limits>
 
+#include <vector>
+#include <cstddef>
 
 namespace batoid {
 
@@ -65,6 +67,54 @@ namespace batoid {
             x[i] = xx;
             y[i] = yy;
             z[i] = zz;
+        }
+    }
+
+    void finishParallelMultiple(
+        const std::vector<double>& origins,  
+        const std::vector<double>& rotations,
+        const std::vector<double>& vv_list,  
+        double* x, double* y, double* z, size_t n
+    ){
+        for (size_t i = 0; i < n; i++) {
+            // Extract direction cosines (each `(x, y, z)` has its own `vv`)
+            double vv0 = vv_list[i * 3], vv1 = vv_list[i * 3 + 1], vv2 = vv_list[i * 3 + 2];
+
+            // Extract corresponding origin
+            double dr0 = origins[i * 3], dr1 = origins[i * 3 + 1], dr2 = origins[i * 3 + 2];
+
+            // Extract corresponding rotation matrix (9 elements)
+            double drot[9] = {
+                rotations[i * 9], rotations[i * 9 + 1], rotations[i * 9 + 2], 
+                rotations[i * 9 + 3], rotations[i * 9 + 4], rotations[i * 9 + 5], 
+                rotations[i * 9 + 6], rotations[i * 9 + 7], rotations[i * 9 + 8]
+            };
+
+            // Compute local velocity components (precomputed to avoid extra calls)
+            double vxlocal = -vv0 * drot[0] - vv1 * drot[3] - vv2 * drot[6];
+            double vylocal = -vv0 * drot[1] - vv1 * drot[4] - vv2 * drot[7];
+            double vzlocal = -vv0 * drot[2] - vv1 * drot[5] - vv2 * drot[8];
+
+            // Process this point (x, y, z)
+            double dx = x[i] - dr0;
+            double dy = y[i] - dr1;
+            double dz = z[i] - dr2;
+
+            // Rotate forward
+            double x_new = dx * drot[0] + dy * drot[3] + dz * drot[6];
+            double y_new = dx * drot[1] + dy * drot[4] + dz * drot[7];
+            double z_new = dx * drot[2] + dy * drot[5] + dz * drot[8];
+
+            // Intersect
+            double dt = -z_new / vzlocal;
+            x_new += dt * vxlocal;
+            y_new += dt * vylocal;
+            z_new += dt * vzlocal;
+
+            // Rotate reverse
+            x[i] = x_new * drot[0] + y_new * drot[1] + z_new * drot[2] + dr0;
+            y[i] = x_new * drot[3] + y_new * drot[4] + z_new * drot[5] + dr1;
+            z[i] = x_new * drot[6] + y_new * drot[7] + z_new * drot[8] + dr2;
         }
     }
 

--- a/src/biconic.cpp
+++ b/src/biconic.cpp
@@ -1,0 +1,92 @@
+#include "biconic.h"
+#include "sphere.h"
+#include <cmath>
+
+namespace batoid {
+
+    #if defined(BATOID_GPU)
+        #pragma omp declare target
+    #endif
+
+    Biconic::Biconic(double Rx, double Ry, double kx, double ky) :
+        _Rx(Rx), _Ry(Ry),
+        _kx(kx), _ky(ky),
+        _cx(1.0 / Rx), _cy(1.0 / Ry) {}
+
+    Biconic::~Biconic() {}
+
+    double Biconic::sag(double x, double y) const {
+        double x_term = _cx * _cx * (1 + _kx) * x * x;
+        double y_term = _cy * _cy * (1 + _ky) * y * y;
+        double sqrt_term = std::sqrt(1 - x_term - y_term);
+        double denom = 1 + sqrt_term;
+
+        if (denom <= 0) return 0.0;
+
+        return (_cx * x * x + _cy * y * y) / denom;
+    }
+
+    void Biconic::normal(double x, double y, double& nx, double& ny, double& nz) const {
+        double x_term = _cx * _cx * (1 + _kx) * x * x;
+        double y_term = _cy * _cy * (1 + _ky) * y * y;
+        double sqrt_term = std::sqrt(1.0 - x_term - y_term);
+        double denom = sqrt_term + 1;
+
+        if (std::abs(denom) < 1e-12) {
+            nx = 0.0;
+            ny = 0.0;
+            nz = 1.0;
+            return;
+        }
+
+        double dzdx = (2 * _cx * x) / denom +
+                      (_cx * _cx * (1 + _kx) * x * (_cx * x * x + _cy * y * y)) /
+                      (sqrt_term * denom * denom);
+
+        double dzdy = (2 * _cy * y) / denom +
+                      (_cy * _cy * (1 + _ky) * y * (_cy * y * y + _cx * x * x)) /
+                      (sqrt_term * denom * denom);
+
+        double dzdr_sq = dzdx * dzdx + dzdy * dzdy;
+        nz = 1.0 / std::sqrt(1.0 + dzdr_sq);
+        nx = -dzdx * nz;
+        ny = -dzdy * nz;
+    }
+
+    bool Biconic::timeToIntersect(
+        double x, double y, double z,
+        double vx, double vy, double vz,
+        double& dt, int niter
+    ) const {
+        // Use Sphere as a good initial guess
+        double R_approx = (_Rx + _Ry) / 2.0;  // Approximate radius of curvature
+        Sphere sphere(R_approx);
+    
+        if (!sphere.timeToIntersect(x, y, z, vx, vy, vz, dt, niter))
+            return false;
+    
+        return Surface::timeToIntersect(x, y, z, vx, vy, vz, dt, niter);
+    }
+    
+
+    #if defined(BATOID_GPU)
+        #pragma omp end declare target
+    #endif
+
+    const Surface* Biconic::getDevPtr() const {
+        #if defined(BATOID_GPU)
+            if (!_devPtr) {
+                Surface* ptr;
+                #pragma omp target map(from:ptr)
+                {
+                    ptr = new Biconic(_Rx, _Ry, _kx, _ky);
+                }
+                _devPtr = ptr;
+            }
+            return _devPtr;
+        #else
+            return this;
+        #endif
+    }
+
+}

--- a/src/obscuration.cpp
+++ b/src/obscuration.cpp
@@ -71,6 +71,43 @@ namespace batoid {
         #pragma omp declare target
     #endif
 
+        ObscEllipse::ObscEllipse(double semi_major, double semi_minor, double x0, double y0) :
+            _semi_major(semi_major), _semi_minor(semi_minor), _x0(x0), _y0(y0)
+        {}
+
+        ObscEllipse::~ObscEllipse() {}
+
+        bool ObscEllipse::contains(double x, double y) const {
+            double dx = x - _x0;
+            double dy = y - _y0;
+            return (dx * dx) / (_semi_major * _semi_major) + (dy * dy) / (_semi_minor * _semi_minor) < 1.0;
+        }
+
+    #if defined(BATOID_GPU)
+        #pragma omp end declare target
+    #endif
+
+    const Obscuration* ObscEllipse::getDevPtr() const {
+        #if defined(BATOID_GPU)
+            if (_devPtr)
+                return _devPtr;
+            Obscuration* ptr;
+            #pragma omp target map(from:ptr)
+            {
+                ptr = new ObscEllipse(_semi_major, _semi_minor, _x0, _y0);
+            }
+            _devPtr = ptr;
+            return ptr;
+        #else
+            return this;
+        #endif
+    }
+
+
+    #if defined(BATOID_GPU)
+        #pragma omp declare target
+    #endif
+
         ObscAnnulus::ObscAnnulus(double inner, double outer, double x0, double y0) :
             _inner(inner), _outer(outer), _x0(x0), _y0(y0)
         {}


### PR DESCRIPTION
- "finishParallelMultiple" added in "batoid.cpp" : similar to "finishParallel" but having the possibility to handle one dirCos for each ray (for point source). 
- handling point source in "_finish" in "rayVector.py"
- computing dirCos between x, y, z coordinates at entrance pupil and point source. Point source coordinates are assumed to be given in the entrance pupil coordinate system: "pointSourceToDirCos" in "utils.py" and has a shape of (3,). Handling "source is not None" in "asGrid", "asPolar", "asSpokes" and "fromStop" in "rayVector.py".
- They are synchronized having the same "time" at the source point. They start at the same "zero" so rays don't necessarily start at the point but a bit before.

- Added elliptical obscuration in "obscuration.cpp" (CPPObscEllipse) and "obscuration.py" (ObscEllipse).

- Added biconic surface (similarly to Zemax) as C++ code (first guess as spherical surface): "CPPBiconic". "Biconic" available in "surface.py".

Everything has been tested and works.