### PR TITLE
Add experimental Windows wheel build support

### DIFF
--- a/include/medium.h
+++ b/include/medium.h
@@ -69,7 +69,9 @@ namespace batoid {
         const Medium* getDevPtr() const override;
 
     private:
-        const double _B1, _B2, _B3, _C1, _C2, _C3;
+        // ``_C1`` / ``_C2`` / ``_C3`` collide with macros from the
+        // Windows SDK (ctype.h), so use a Sellmeier-prefixed name.
+        const double _B1, _B2, _B3, _sellC1, _sellC2, _sellC3;
     };
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,12 +36,32 @@ class CMakeBuild(build_ext):
             "-DPYTHON_EXECUTABLE=" + sys.executable,
         ]
 
+        # Make pybind11 discoverable in PEP 517 isolated builds, where
+        # CMake's normal find_package would not see the temporary site
+        # packages.  ``python -m pybind11 --cmakedir`` returns the
+        # directory shipped with the pybind11 wheel.
+        try:
+            import pybind11
+            cmake_args.append("-Dpybind11_DIR=" + pybind11.get_cmake_dir())
+        except (ImportError, AttributeError):
+            pass
+
         cfg = "Debug" if self.debug else "RelWithDebInfo"
         build_args = ["--config", cfg]
 
         cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
+        # Hand parallelism to ``cmake --build --parallel`` instead of
+        # forwarding ``-j8`` to the underlying tool: MSBuild rejects
+        # ``-j8`` outright (it expects ``/m`` or ``-maxCpuCount``), while
+        # Make/Ninja are happy with the CMake-level flag.  ``--parallel``
+        # picks up CMAKE_BUILD_PARALLEL_LEVEL when set, or defaults to a
+        # generator-appropriate count.
         if "TF_BUILD" not in env:
-            build_args += ["--", "-j8"]
+            jobs = os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL")
+            if jobs:
+                build_args += ["--parallel", str(jobs)]
+            else:
+                build_args += ["--parallel"]
 
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)

--- a/src/batoid.cpp
+++ b/src/batoid.cpp
@@ -1,4 +1,5 @@
 #include "batoid.h"
+#include <cstddef>  // ptrdiff_t for OpenMP-safe signed loop counters on MSVC.
 #include <limits>
 
 
@@ -10,8 +11,12 @@ namespace batoid {
         double* x, double* y, double* z,
         size_t n, int max_threads
     ) {
+        // MSVC's OpenMP requires a signed integral loop counter; reuse a
+        // ptrdiff_t mirror of ``n`` so the parallel-for index can be signed
+        // without clipping.
+        ptrdiff_t nloop = static_cast<ptrdiff_t>(n);
         #pragma omp parallel for num_threads(max_threads)
-        for(size_t i=0; i<n; i++) {
+        for(ptrdiff_t i=0; i<nloop; i++) {
             double dx = x[i]-dr[0];
             double dy = y[i]-dr[1];
             double dz = z[i]-dr[2];
@@ -26,8 +31,9 @@ namespace batoid {
         double* x, double* y, double* z,
         size_t n, int max_threads
     ) {
+        ptrdiff_t nloop = static_cast<ptrdiff_t>(n);
         #pragma omp parallel for num_threads(max_threads)
-        for(size_t i=0; i<n; i++) {
+        for(ptrdiff_t i=0; i<nloop; i++) {
             double xx = x[i]*drot[0] + y[i]*drot[1] + z[i]*drot[2] + dr[0];
             double yy = x[i]*drot[3] + y[i]*drot[4] + z[i]*drot[5] + dr[1];
             double zz = x[i]*drot[6] + y[i]*drot[7] + z[i]*drot[8] + dr[2];

--- a/src/medium.cpp
+++ b/src/medium.cpp
@@ -137,7 +137,8 @@ namespace batoid {
             double B1, double B2, double B3,
             double C1, double C2, double C3
         ) :
-            Medium(), _B1(B1), _B2(B2), _B3(B3), _C1(C1), _C2(C2), _C3(C3)
+            Medium(), _B1(B1), _B2(B2), _B3(B3),
+            _sellC1(C1), _sellC2(C2), _sellC3(C3)
         {}
 
         SellmeierMedium::~SellmeierMedium() {}
@@ -145,7 +146,7 @@ namespace batoid {
         double SellmeierMedium::getN(double wavelength) const {
             // Sellmeier coefficients assume wavelength is in microns, so we have to multiply (1e6)**2
             double x = wavelength*wavelength*1e12;
-            return std::sqrt(1.0 + _B1*x/(x-_C1) + _B2*x/(x-_C2) + _B3*x/(x-_C3));
+            return std::sqrt(1.0 + _B1*x/(x-_sellC1) + _B2*x/(x-_sellC2) + _B3*x/(x-_sellC3));
         }
 
     #if defined(BATOID_GPU)
@@ -160,7 +161,7 @@ namespace batoid {
             Medium* ptr;
             #pragma omp target map(from:ptr)
             {
-                ptr = new SellmeierMedium(_B1, _B2, _B3, _C1, _C2, _C3);
+                ptr = new SellmeierMedium(_B1, _B2, _B3, _sellC1, _sellC2, _sellC3);
             }
             _devPtr = ptr;
             return ptr;

--- a/src/obscuration.cpp
+++ b/src/obscuration.cpp
@@ -212,7 +212,7 @@ namespace batoid {
                             if (y1 != y2) {
                                 xinters = (y-y1)*(x2-x1)/(y2-y1)+x1;
                             }
-                            if (x1 == x2 or x <= xinters) {
+                            if (x1 == x2 || x <= xinters) {
                                 inside = !inside;
                             }
                         }
@@ -251,7 +251,7 @@ namespace batoid {
         xinters.reserve(16);  // 2 is probably most common, but it's cheap to allocate 16
         for (int j=0; j<ny; j++) {
             double y = ygrid[j];
-            if ((y < ymin) or (y > ymax)) {
+            if ((y < ymin) || (y > ymax)) {
                 for (int i=0; i<nx; i++) {
                     out[j*nx+i] = false;
                 }

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -58,7 +58,7 @@ namespace batoid {
     double Table::eval(double x, double y) const {
         int ix = int(std::floor((x-_x0)/_dx));
         int iy = int(std::floor((y-_y0)/_dy));
-        if ((ix >= (_nx-1)) or (ix < 0) or (iy >= (_ny-1)) or (iy < 0)) {
+        if ((ix >= (_nx-1)) || (ix < 0) || (iy >= (_ny-1)) || (iy < 0)) {
             return _use_nan ? NAN : 0.0;
         }
         double xgrid = _x0 + ix*_dx;
@@ -95,7 +95,7 @@ namespace batoid {
     ) const {
         int ix = int(std::floor((x-_x0)/_dx));
         int iy = int(std::floor((y-_y0)/_dy));
-        if ((ix >= (_nx-1)) or (ix < 0) or (iy >= (_ny-1)) or (iy < 0)) {
+        if ((ix >= (_nx-1)) || (ix < 0) || (iy >= (_ny-1)) || (iy < 0)) {
             if (_use_nan) {
                 dzdx = NAN;
                 dzdy = NAN;


### PR DESCRIPTION
> Depends on GalSim PR GalSim-developers/GalSim#1359.

Draft PR against `releases/0.8` (baseline `367a861`, v0.8.0).
Branch on file: `windows-port`.

## Status

- **Verified locally**: `pip install . -v` (Ninja+MSVC), `pip wheel`,
  `delvewheel repair`, fresh-venv install with separately-built GalSim
  Windows wheel (no conda PATH), `import batoid`, LSST yaml load,
  raytrace, SellmeierMedium, ObscPolygon, Bicubic, and **176 / 204
  pytest cases passing**.
- **Test failures (28)** are all in `tests/test_notebooks.py`, all
  `ModuleNotFoundError: No module named 'nbformat'` — jupyter test
  infra not installed. Not Windows-specific.
- **Linux / macOS code paths are textually unchanged** outside the
  member rename and the `or`->`||` swap (which GCC/Clang accept
  identically). Existing CI should pass without changes; not re-run
  from this branch.

## Dependency

batoid depends on GalSim. GalSim does not currently ship Windows
wheels; a companion PR adds Windows support to GalSim
(`releases/2.8` branch, `windows-msvc-port`). Once that PR or a
subsequent GalSim release exposes a `win_amd64` wheel on PyPI, this
PR's wheel becomes installable purely with `pip install`. Until then,
end users on Windows would need to install GalSim from the companion
branch.

This PR does not change `install_requires=['galsim', ...]`; it only
enables batoid itself to build.

## Summary

Three small commits make batoid build, install, and pass its
non-notebook test suite on native Windows x64 with the MSVC
toolchain. The patches address one Windows-SDK macro collision, three
independent MSVC source-level issues, and two CMake / pybind11 build
quirks. Diff totals +40 / -11 across six files.

## What this PR changes

| # | Commit | Files | Diff |
|---|---|---|---|
| 1 | Avoid Windows SDK macro collision in SellmeierMedium | `include/medium.h`, `src/medium.cpp` | +7 / -4 |
| 2 | Make batoid C++ sources MSVC compatible | `src/batoid.cpp`, `src/obscuration.cpp`, `src/table.cpp` | +12 / -6 |
| 3 | Make batoid CMake extension build portable on Windows | `setup.py` | +21 / -1 |

Branch tip: `d28bc8a`.

<details><summary><strong>Per-commit detail</strong> (click to expand)</summary>

### 1. SellmeierMedium macro collision

The Windows SDK header `ctype.h` defines preprocessor macros named
`_C1`, `_C2`, `_C3` (control-character classification masks).
Including `Windows.h` — which any Windows MSVC translation unit
eventually does — expands those macros over the matching
SellmeierMedium private members and the file no longer parses.

Rename to `_sellC1` / `_sellC2` / `_sellC3` with a one-line comment
in the header explaining why. Updates the constructor's
member-initializer list, `getN()`, and the `BATOID_GPU` device-pointer
constructor. Public API and Sellmeier coefficient ordering unchanged.

### 2. C++ sources for MSVC

Three independent fixes:

- `src/batoid.cpp`: convert the two `#pragma omp parallel for` loops
  in `applyForwardTransformArrays` / `applyReverseTransformArrays`
  from `size_t i` to `ptrdiff_t i` (with a `ptrdiff_t nloop =
  static_cast<ptrdiff_t>(n)` mirror so the upper bound width is
  preserved). MSVC OpenMP requires a signed integral loop counter.
  Other parallel loops in this file already used `int i` and did not
  need touching. Adds `<cstddef>` for `ptrdiff_t`.
- `src/obscuration.cpp`: replace `or` with `||` in the polygon
  point-in-polygon test and the y-grid bounds early-exit. MSVC parses
  `or` as an identifier without `/Za` plus `<ciso646>`.
- `src/table.cpp`: replace `or` with `||` in the two bounds-check
  expressions in `Table::eval` and the gradient variant.

### 3. CMake extension build for Windows

`setup.py` only:

- Drop `build_args += ["--", "-j8"]` and replace with
  `build_args += ["--parallel", str(jobs)]` driven by
  `CMAKE_BUILD_PARALLEL_LEVEL`, falling back to a bare `--parallel`.
  MSBuild rejects `-j8` outright (it expects `/m` / `-maxCpuCount`);
  `--parallel` is generator-agnostic.
- Add `-Dpybind11_DIR=` from `pybind11.get_cmake_dir()` to
  `cmake_args`, guarded by a try/except around `import pybind11`.
  PEP 517 isolated builds install pybind11 in a temporary directory
  that CMake's `find_package(pybind11)` cannot otherwise discover.

</details>

## Verification

Built and tested on Windows 11 x64, Python 3.11.15 (conda-forge), VS
2026 Community (MSVC 14.50.35717), CMake 3.30, Ninja 1.13, pybind11
3.0.3.

### Build / wheel

```
pip install . -v --no-build-isolation                 # 0 errors
pip wheel . -w dist -v --no-build-isolation --no-deps # 0 errors
delvewheel show dist\batoid-*-win_amd64.whl           # see table
delvewheel repair --add-path %CONDA_PREFIX%\Library\bin \
                  -w wheelhouse dist\batoid-*-win_amd64.whl
```

| Bundled into wheel | Assumed present on host |
| --- | --- |
| `msvcp140.dll` | `vcruntime140.dll`, `vcruntime140_1.dll` |
| `vcomp140.dll` | `python311.dll`, `kernel32.dll`, `api-ms-win-crt-*` |

batoid does not link FFTW directly (the FFT dependency goes through
GalSim), so the batoid wheel does not bundle `fftw3.dll`.

### Smoke (touches each patch)

| Test | Result | Patch covered |
| --- | --- | --- |
| `import batoid` | `0.1.dev1069+gd28bc8a36` | build / setup.py |
| `SellmeierMedium(BK7).getN(550 nm)` | `1.5185223876207927` | SellmeierMedium rename |
| `Optic.fromYaml('LSST_r.yaml')` | 4 sub-items | end-to-end |
| LSST_r raytrace, polar, theta=(0.5deg, 0) | 132 rays in, 114 not vignetted/failed, ~2 um focal-plane spread | OpenMP parallel-for |
| `ObscPolygon([0,1,1,0],[0,0,1,1]).contains(0.5,0.5) / (2,2)` | `True` / `False` | obscuration.cpp `or` |
| `Bicubic` of `0.01*(x*x+y*y)`, sag at (0.2, 0.3) and off-grid (5,5) | `0.0013...` / `nan` | table.cpp `or` |

### Full pytest

```
:: Run from outside the source tree so pytest resolves the installed
:: package, not the source-layout `batoid/` subdir.
python -m pytest batoid/tests/ -o "addopts=--durations=10 -ra" --timeout=180 --rootdir=batoid
```

**176 passed, 28 failed** in 62 s. The 28 failures are all in
`tests/test_notebooks.py`, all `ModuleNotFoundError: No module named
'nbformat'` (jupyter test infra not installed; not Windows-specific).

The 176 passing tests cover Asphere, Bicubic, Coating, CoordSys,
CoordTransform, Lattice, Medium, OPDScreen, Obscuration, Optic,
Paraboloid, Plane, Quadric, RayVector, Sphere, Sum, Tilted, Zernike,
analysis, plot, zemax. The OpenMP parallel paths and both alt-token
sites are exercised.

<details><summary>Slowest test cases (top 3)</summary>

| Test | Time |
| --- | --- |
| `tests/test_zemax.py::test_HSC_huygensPSF` | 11.55 s |
| `tests/test_analysis.py::test_doubleZernike` | 2.64 s |
| `tests/test_Asphere.py::test_sag` | 1.47 s |

</details>

### Fresh-venv install (no conda PATH)

```
python -m venv .venv-clean
:: PATH set to .venv-clean\Scripts;System32;... (no conda Library\bin)
.venv-clean\Scripts\pip install <galsim-2.8.4-cp311-...whl> LSSTDESC.Coord astropy
.venv-clean\Scripts\pip install <batoid-...-cp311-...whl> pyyaml scipy matplotlib
.venv-clean\Scripts\python batoid_smoke.py
```

The cleaned PATH does not include `%CONDA_PREFIX%\Library\bin`. The
six smoke tests above pass with byte-identical numeric output to the
conda-env run, demonstrating the wheel is self-contained modulo the
GalSim wheel's bundled FFTW.

## Wheel notes

- Bundled DLLs: `msvcp140.dll`, `vcomp140.dll`. No FFTW (uses
  GalSim's).
- `vcomp140.dll` is the Microsoft OpenMP runtime, used by the loops
  in `batoid.cpp` / `obscuration.cpp`. Choosing `/openmp:llvm` would
  switch this to `libomp.dll`. This PR keeps the simpler `/openmp`
  (set via CMake's `find_package(OpenMP)`).
- Wheel size: ~8.5 MB; ~6 MB of that is the bundled
  LSST/Rubin/HSC/DECam YAML data files, not C++ code.

## Follow-ups

None blocking; each is a separate PR candidate.

- **GitHub Actions CI**: a `windows-latest` job + `cibuildwheel`
  matrix (`cp39 .. cp313 -win_amd64`). Better aligned after the
  GalSim Windows wheel is upstream so batoid CI can `pip install
  galsim` directly.
- **Notebook tests**: install `nbformat`, `nbclient`, `ipyvolume` in
  CI Windows so the 28 `test_notebooks.py` cases run.
- **`Python_EXECUTABLE` -> `Python3_EXECUTABLE` migration**:
  `setup.py` still passes the older form. Works today; can be
  modernized in a separate PR.

## Risk and compatibility

- **Linux / macOS**: every change is either Windows-only logic
  guarded by `_WIN32` / generator-aware (`setup.py`) or a textual
  swap that GCC/Clang accept identically (`or` -> `||`,
  `size_t` -> `ptrdiff_t`, member rename).
- **OpenMP loop counter signed-vs-unsigned change**: switching
  `size_t i` to `ptrdiff_t i` on a 64-bit platform preserves range
  for any practical batoid input.
- **Sellmeier rename**: members are private; not part of the
  documented API.
- **MSVC toolset vs bundled runtime**: `delvewheel` warns when the
  bundled `msvcp140.dll` is older than the toolset that built the
  `.pyd`. Locally I built with VS 2026 (14.50) and bundled
  conda-forge's 14.44 redistributable. Smoke and pytest both ran
  cleanly. CI on `windows-latest` (VS 2022, 14.4x) would not see
  the mismatch.

## Reviewer questions

1. **GalSim Windows wheel timeline**: should I plan around it, or is
   it acceptable to land this batoid PR ahead of the GalSim PR (with
   a note that `pip install` is gated until GalSim ships a Windows
   wheel)?
2. **`/openmp` vs `/openmp:llvm`** for the eventual CI/wheel build.
3. **`PYTHON_EXECUTABLE` -> `Python3_EXECUTABLE`** migration: fold
   into this PR, or separate?
4. **CI**: a `windows-latest` + cibuildwheel workflow can follow
   once questions 1-2 are settled. Draft strategy available locally
   if helpful.

Happy to split, rebase, or extend as the project prefers.
