### PR TITLE
Add v1000 files.

### DIFF
--- a/batoid/coordSys.py
+++ b/batoid/coordSys.py
@@ -61,6 +61,23 @@ class CoordSys:
         """
         return self.rot[:, 2]
 
+    def euler(self):
+        """Return (rotX, rotY, rotZ) Euler angles in radians.
+
+        Angles follow the intrinsic XYZ Tait-Bryan convention used by
+        parse_coordSys: R = RotX(rx) @ RotY(ry) @ RotZ(rz).
+
+        Returns
+        -------
+        rx, ry, rz : float
+            Rotation angles in radians about the local X, Y, Z axes.
+        """
+        R = self.rot
+        ry = np.arcsin(R[0, 2])
+        rx = np.arctan2(-R[1, 2], R[2, 2])
+        rz = np.arctan2(-R[0, 1], R[0, 0])
+        return rx, ry, rz
+
     def shiftGlobal(self, dr):
         """Return new CoordSys with origin shifted along global axes.
 

--- a/batoid/data/LSST/LSST_r_baffles_LTS-213.yaml
+++ b/batoid/data/LSST/LSST_r_baffles_LTS-213.yaml
@@ -387,17 +387,6 @@ opticalSystem:
         z: 5.352
     -
       type: Baffle
-      name: CameraBody
-      parent: LSSTCamera  # physically attached to camera; moves with it under rigid-body ops
-      surface:
-        type: Plane
-      obscuration:
-        type: ObscCircle
-        radius: 0.80469  # = 1.60938/2 m; camera body outer diameter
-      coordSys:
-        z: 3.5019725882045593  # L1_entrance (3.3974725882045593) + 0.1045 m
-    -
-      type: Baffle
       name: Center
       surface:
         type: Plane
@@ -457,6 +446,17 @@ opticalSystem:
         inner: 0.9
       coordSys:
         z: 6.1562006
+    -
+      type: Baffle
+      name: CameraBody
+      parent: LSSTCamera  # physically attached to camera; moves with it under rigid-body ops
+      surface:
+        type: Plane
+      obscuration:
+        type: ObscCircle
+        radius: 0.80469  # = 1.60938/2 m; camera body outer diameter
+      coordSys:
+        z: 3.5019725882045593  # L1_entrance (3.3974725882045593) + 0.1045 m
     -
       type: Mirror
       name: M3

--- a/batoid/data/LSST/Rubin_v1000_g.yaml
+++ b/batoid/data/LSST/Rubin_v1000_g.yaml
@@ -1,0 +1,337 @@
+# Add M1, M1M3, and inner hole baffles from priv comm with R. Tighe.
+# We'll add the M1 baffle as a separate optic.  But for the M1M3 Baffle
+# and inner hole baffle we'll just change the obscuration for M1 and M3
+# directly.
+# Also adjust the entrance pupil to match the M1 Baffle.
+
+opticalSystem:
+  type: CompoundOptic
+  name: LSST
+  inMedium: &vacuum 1.0
+  medium: *vacuum
+  backDist: 15.0  # distance from global vertex to use to start tracing rays
+  sphereRadius: 5.0  # reference sphere radius to use for wavefront calculation
+  pupilSize: 8.33  # Pupil fits inside a square with this side length
+  pupilObscuration: 0.612  # Fractional pupil central obscuration
+  stopSurface:
+    type: Interface
+    name: entrancePupil
+    surface:
+      type: Plane
+    coordSys:
+      z: 0.48283
+  items:
+    -
+      type: Baffle
+      name: M1Baffle1
+      surface:
+        type: Plane
+      obscuration:
+        type: ClearCircle
+        radius: 4.165
+      coordSys:
+        z: 0.48283
+    -
+      type: Mirror
+      name: M1
+      surface:
+        type: Asphere
+        R: 19.8346                # 1/CURV
+        conic: -1.21502           # CONI
+        coefs: [0.0, -1.381e-9]   # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 4.18
+        inner: 2.5833  # R. Tighe. priv comm
+    -
+      type: Baffle
+      name: M1Baffle2
+      surface:
+        type: Plane
+      obscuration:
+        type: ClearCircle
+        radius: 4.165
+      coordSys:
+        z: 0.48283
+    -
+      type: Mirror
+      name: M2
+      surface:
+        type: Asphere
+        R: 6.79005                # 1/CURV
+        conic: -0.222             # CONI
+        coefs: [0.0, 1.274e-5, 9.68e-7] # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 1.71
+        inner: 0.9
+      coordSys:
+        # From COORDBRK
+        x: -2.2999986825621125e-05
+        y:  1.300002205197993e-05
+        z: 6.15535506215  # CUMSUM of DISZ
+        rotX: 1.016654289286697e-05  # -np.deg2rad(-0.0005825)
+        rotY: -6.073745796940267e-06  # np.deg2rad(-0.000348)
+    -
+      type: Baffle
+      name: CameraBody
+      parent: LSSTCamera  # physically attached to camera; moves with it under rigid-body ops
+      surface:
+        type: Plane
+      obscuration:
+        type: ObscCircle
+        radius: 0.80469  # = 1.60938/2 m; camera body outer diameter
+      coordSys:
+        x: -0.0009089130556575664
+        y: -0.00023347981008824386
+        z: 3.5013800028404387
+        rotX: 0.00013010556419248287
+        rotY: 0.0001844974335291165
+        rotZ: -1.4239829750999484e-08
+    -
+      type: Mirror
+      name: M3
+      surface:
+        type: Asphere
+        R: 8.3439       # 1/CURV
+        conic: 0.15497  # CONI
+        coefs: [0.0, 4.5e-7, 8.15e-9]  # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 2.48511  # R. Tighe. priv comm
+        inner: 0.52735  # R. Tighe. priv comm
+      coordSys:
+        # From accumulated coordinate transforms
+        x: -3.6299998682604528e-04
+        y: -1.6899997794876846e-04
+        z: -2.3439999999999817e-01
+        rotX: -2.3387411999344819e-05
+        rotY: 4.3982297138228580e-05
+    -
+      type: CompoundOptic
+      name: LSSTCamera
+      coordSys:
+        # accumulated transforms
+        x: -9.2819303735197948e-04
+        y: -2.1988377889988682e-04
+        z: 3.3968800055034518e+00
+        rotX: 1.3010556419248284e-04
+        rotY: 1.8449743352911649e-04
+        rotZ: -1.4239829750999484e-08
+      items:
+        -
+          type: Lens
+          name: L1
+          medium: &silica
+            # from fitting Sellmeier coefs to [ugriz]_prescription index data
+            type: SellmeierMedium
+            B1: 0.6961829842616872
+            B2: 0.4079259129074905
+            B3: 0.8974643319456314
+            C1: 0.004679264915537484
+            C2: 0.013512224089229979
+            C3: 97.93239315034683
+          items:
+            -
+              type: RefractiveInterface
+              name: L1_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: 2.823354  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.775
+                    # To convert Zemax -> batoid, need to flip x, y, z => -x, y, -z
+                    # Amounts to flipping signs of
+                    # Z1, Z3, Z4, Z6, Z7, Z9, Z11, Z12, Z14, Z17, Z19, Z21, Z22, Z24, Z26, Z28
+                    coef:
+                      -  0.0
+                      - -5.099E-10  # Z1
+                      -  9.089E-11  # Z2
+                      -  2.151E-10  # Z3
+                      -  4.171E-08  # Z4
+                      -  4.549E-09  # Z5
+                      - -3.728E-08  # Z6
+                      -  1.441E-08  # Z7
+                      -  1.791E-08  # Z8
+                      -  3.841E-09  # Z9
+                      - -1.684E-08  # Z10
+                      - -3.002E-08  # Z11
+                      - -1.249E-08  # Z12
+                      - -4.490E-09  # Z13
+                      - -7.715E-09  # Z14
+                      -  1.197E-09  # Z15
+                      -  7.780E-09  # Z16
+                      - -1.189E-08  # Z17
+                      - -1.902E-09  # Z18
+                      -  5.311E-09  # Z19
+                      - -5.026E-09  # Z20
+                      -  8.985E-09  # Z21
+                      - -1.321E-08  # Z22
+                      - -7.393E-09  # Z23
+                      - -9.319E-09  # Z24
+                      - -3.555E-09  # Z25
+                      - -5.699E-09  # Z26
+                      - -7.704E-09  # Z27
+                      - -1.860E-08  # Z28
+              obscuration:
+                type: ClearCircle
+                radius: 0.775
+            -
+              type: RefractiveInterface
+              name: L1_exit
+              surface:
+                type: Sphere
+                R: 5.018956  # 1/CURV
+              obscuration:
+                type: ClearCircle
+                radius: 0.775
+              coordSys:
+                z: 0.08231  # DISZ
+        -
+          type: Lens
+          name: L2
+          medium: *silica
+          coordSys:
+            z: 0.494881  # cumsum of some DISZ, checked against global vertex coord
+          items:
+            -
+              type: RefractiveInterface
+              name: L2_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: -48040.0  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.551
+                    coef:
+                      - -0.0
+                      -  8.408e-09
+                      -  1.927e-09
+                      -  1.502e-09
+                      - -4.473e-08
+                      -  2.731e-09
+                      -  6.184e-08
+                      -  1.834e-09
+                      -  2.354e-09
+                      - -3.440e-08
+                      - -1.255e-08
+                      -  5.409e-08
+                      -  7.787e-09
+                      - -3.49e-09
+                      - -1.172e-09
+                      - -4.626e-09
+                      -  4.564e-09
+                      -  3.556e-09
+                      -  3.987e-09
+                      -  5.803e-09
+                      - -2.950e-09
+                      -  2.986e-09
+                      -  4.575e-08
+                      - -9.143e-10
+                      - -5.526e-10
+                      - -4.372e-09
+                      - -5.158e-10
+                      -  1.471e-09
+                      -  1.916e-09
+              obscuration:
+                type: ClearCircle
+                radius: 0.551
+            -
+              type: RefractiveInterface
+              name: L2_exit
+              surface:
+                type: Asphere
+                R: 2.5291       # 1/CURV
+                conic: -1.57    # CONI
+                coefs: [0.0, -0.001656]  # PARM
+              obscuration:
+                type: ClearCircle
+                radius: 0.551
+              coordSys:
+                z: 0.03005
+        -
+          type: Lens
+          name: Filter
+          medium: *silica
+          coordSys:
+            # accumulated transforms
+            x: -1.7328056696161860e-04
+            y: -2.7620000000000005e-04
+            z: 8.7116838944881725e-01
+            rotY: -7.5049157835756176e-05
+          items:
+            -
+              type: RefractiveInterface
+              name: Filter_entrance
+              surface:
+                type: Sphere
+                R: 5.632  # 1/CURV
+                # Note: For r and i band, read Zernike coefficients from multi-config data.
+              obscuration:
+                type: ClearCircle
+                radius: 0.375
+            -
+              type: RefractiveInterface
+              name: Filter_exit
+              surface:
+                type: Sphere
+                R: 5.576  # 1/CRVT from multi-configuration
+              obscuration:
+                type: ClearCircle
+                radius: 0.375
+              coordSys:
+                z: 0.0215  # THIC from multi-configuration
+        -
+          type: Lens
+          name: L3
+          medium: *silica
+          coordSys:
+            x: -1.7867810238809937e-04
+            y: -2.7620000000000010e-04
+            z: 9.4308838924627658e-01
+            rotY: -7.5049157835756176e-05
+          items:
+            -
+              type: RefractiveInterface
+              name: L3_entrance
+              surface:
+                type: Quadric
+                R: 3.169       # 1/CURV
+                conic: -0.962  # CONI
+              obscuration:
+                type: ClearCircle
+                radius: 0.361
+            -
+              type: RefractiveInterface
+              name: L3_exit
+              surface:
+                type: Sphere
+                R: -13.36   # 1/CURV
+              obscuration:
+                type: ClearCircle
+                radius: 0.361
+              coordSys:
+                z: 0.06008  #DISZ
+        -
+          type: Detector
+          name: Detector
+          surface:
+            type: Plane
+          obscuration:
+            type: ClearCircle
+            radius: 0.4
+          coordSys:
+            # accumulated transforms
+            x: -1.8535755247836943e-04
+            y: -2.7619999999999988e-04
+            z: 1.0320893889956335e+00
+            rotX: -2.0064305269723316e-04
+            rotY: -1.3718287644542526e-04
+            rotZ: -2.7524791390826322e-08

--- a/batoid/data/LSST/Rubin_v1000_i.yaml
+++ b/batoid/data/LSST/Rubin_v1000_i.yaml
@@ -1,0 +1,372 @@
+# Add M1, M1M3, and inner hole baffles from priv comm with R. Tighe.
+# We'll add the M1 baffle as a separate optic.  But for the M1M3 Baffle
+# and inner hole baffle we'll just change the obscuration for M1 and M3
+# directly.
+# Also adjust the entrance pupil to match the M1 Baffle.
+
+opticalSystem:
+  type: CompoundOptic
+  name: LSST
+  inMedium: &vacuum 1.0
+  medium: *vacuum
+  backDist: 15.0  # distance from global vertex to use to start tracing rays
+  sphereRadius: 5.0  # reference sphere radius to use for wavefront calculation
+  pupilSize: 8.33  # Pupil fits inside a square with this side length
+  pupilObscuration: 0.612  # Fractional pupil central obscuration
+  stopSurface:
+    type: Interface
+    name: entrancePupil
+    surface:
+      type: Plane
+    coordSys:
+      z: 0.48283
+  items:
+    -
+      type: Baffle
+      name: M1Baffle1
+      surface:
+        type: Plane
+      obscuration:
+        type: ClearCircle
+        radius: 4.165
+      coordSys:
+        z: 0.48283
+    -
+      type: Mirror
+      name: M1
+      surface:
+        type: Asphere
+        R: 19.8346                # 1/CURV
+        conic: -1.21502           # CONI
+        coefs: [0.0, -1.381e-9]   # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 4.18
+        inner: 2.5833  # R. Tighe. priv comm
+    -
+      type: Baffle
+      name: M1Baffle2
+      surface:
+        type: Plane
+      obscuration:
+        type: ClearCircle
+        radius: 4.165
+      coordSys:
+        z: 0.48283
+    -
+      type: Mirror
+      name: M2
+      surface:
+        type: Asphere
+        R: 6.79005                # 1/CURV
+        conic: -0.222             # CONI
+        coefs: [0.0, 1.274e-5, 9.68e-7] # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 1.71
+        inner: 0.9
+      coordSys:
+        # From COORDBRK
+        x: -2.2999986825621125e-05
+        y:  1.300002205197993e-05
+        z: 6.15535506215  # CUMSUM of DISZ
+        rotX: 1.016654289286697e-05  # -np.deg2rad(-0.0005825)
+        rotY: -6.073745796940267e-06  # np.deg2rad(-0.000348)
+    -
+      type: Baffle
+      name: CameraBody
+      parent: LSSTCamera  # physically attached to camera; moves with it under rigid-body ops
+      surface:
+        type: Plane
+      obscuration:
+        type: ObscCircle
+        radius: 0.80469  # = 1.60938/2 m; camera body outer diameter
+      coordSys:
+        x: -0.0009089130556575664
+        y: -0.00023347981008824386
+        z: 3.499547228763904
+        rotX: 0.00013010556419248287
+        rotY: 0.0001844974335291165
+        rotZ: -1.4239829750999484e-08
+    -
+      type: Mirror
+      name: M3
+      surface:
+        type: Asphere
+        R: 8.3439       # 1/CURV
+        conic: 0.15497  # CONI
+        coefs: [0.0, 4.5e-7, 8.15e-9]  # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 2.48511  # R. Tighe. priv comm
+        inner: 0.52735  # R. Tighe. priv comm
+      coordSys:
+        # From accumulated coordinate transforms
+        x: -3.6299998682604528e-04
+        y: -1.6899997794876846e-04
+        z: -2.3439999999999817e-01
+        rotX: -2.3387411999344819e-05
+        rotY: 4.3982297138228580e-05
+    -
+      type: CompoundOptic
+      name: LSSTCamera
+      coordSys:
+        # accumulated transforms
+        x: -9.2819303735197948e-04
+        y: -2.1988377889988682e-04
+        z: 3.3950472314269171e+00
+        rotX: 1.3010556419248284e-04
+        rotY: 1.8449743352911649e-04
+        rotZ: -1.4239829750999484e-08
+      items:
+        -
+          type: Lens
+          name: L1
+          medium: &silica
+            # from fitting Sellmeier coefs to [ugriz]_prescription index data
+            type: SellmeierMedium
+            B1: 0.6961829842616872
+            B2: 0.4079259129074905
+            B3: 0.8974643319456314
+            C1: 0.004679264915537484
+            C2: 0.013512224089229979
+            C3: 97.93239315034683
+          items:
+            -
+              type: RefractiveInterface
+              name: L1_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: 2.823354  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.775
+                    # To convert Zemax -> batoid, need to flip x, y, z => -x, y, -z
+                    # Amounts to flipping signs of
+                    # Z1, Z3, Z4, Z6, Z7, Z9, Z11, Z12, Z14, Z17, Z19, Z21, Z22, Z24, Z26, Z28
+                    coef:
+                      -  0.0
+                      - -5.099E-10  # Z1
+                      -  9.089E-11  # Z2
+                      -  2.151E-10  # Z3
+                      -  4.171E-08  # Z4
+                      -  4.549E-09  # Z5
+                      - -3.728E-08  # Z6
+                      -  1.441E-08  # Z7
+                      -  1.791E-08  # Z8
+                      -  3.841E-09  # Z9
+                      - -1.684E-08  # Z10
+                      - -3.002E-08  # Z11
+                      - -1.249E-08  # Z12
+                      - -4.490E-09  # Z13
+                      - -7.715E-09  # Z14
+                      -  1.197E-09  # Z15
+                      -  7.780E-09  # Z16
+                      - -1.189E-08  # Z17
+                      - -1.902E-09  # Z18
+                      -  5.311E-09  # Z19
+                      - -5.026E-09  # Z20
+                      -  8.985E-09  # Z21
+                      - -1.321E-08  # Z22
+                      - -7.393E-09  # Z23
+                      - -9.319E-09  # Z24
+                      - -3.555E-09  # Z25
+                      - -5.699E-09  # Z26
+                      - -7.704E-09  # Z27
+                      - -1.860E-08  # Z28
+              obscuration:
+                type: ClearCircle
+                radius: 0.775
+            -
+              type: RefractiveInterface
+              name: L1_exit
+              surface:
+                type: Sphere
+                R: 5.018956  # 1/CURV
+              obscuration:
+                type: ClearCircle
+                radius: 0.775
+              coordSys:
+                z: 0.08231  # DISZ
+        -
+          type: Lens
+          name: L2
+          medium: *silica
+          coordSys:
+            z: 0.494881  # cumsum of some DISZ, checked against global vertex coord
+          items:
+            -
+              type: RefractiveInterface
+              name: L2_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: -48040.0  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.551
+                    coef:
+                      - -0.0
+                      -  8.408e-09
+                      -  1.927e-09
+                      -  1.502e-09
+                      - -4.473e-08
+                      -  2.731e-09
+                      -  6.184e-08
+                      -  1.834e-09
+                      -  2.354e-09
+                      - -3.440e-08
+                      - -1.255e-08
+                      -  5.409e-08
+                      -  7.787e-09
+                      - -3.49e-09
+                      - -1.172e-09
+                      - -4.626e-09
+                      -  4.564e-09
+                      -  3.556e-09
+                      -  3.987e-09
+                      -  5.803e-09
+                      - -2.950e-09
+                      -  2.986e-09
+                      -  4.575e-08
+                      - -9.143e-10
+                      - -5.526e-10
+                      - -4.372e-09
+                      - -5.158e-10
+                      -  1.471e-09
+                      -  1.916e-09
+              obscuration:
+                type: ClearCircle
+                radius: 0.551
+            -
+              type: RefractiveInterface
+              name: L2_exit
+              surface:
+                type: Asphere
+                R: 2.5291       # 1/CURV
+                conic: -1.57    # CONI
+                coefs: [0.0, -0.001656]  # PARM
+              obscuration:
+                type: ClearCircle
+                radius: 0.551
+              coordSys:
+                z: 0.03005
+        -
+          type: Lens
+          name: Filter
+          medium: *silica
+          coordSys:
+            # accumulated transforms
+            x: -1.7328056696161860e-04
+            y: -2.7620000000000005e-04
+            z: 8.7116838944881725e-01
+            rotY: -7.5049157835756176e-05
+          items:
+            -
+              type: RefractiveInterface
+              name: Filter_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: 5.632  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.378
+                    coef:
+                      -  0.0
+                      - -3.892e-10  # Z1
+                      -  2.751e-10  # Z2
+                      - -9.948e-11  # Z3
+                      - -3.843e-10  # Z4
+                      - -1.470e-08  # Z5
+                      - -9.988e-08  # Z6
+                      - -6.916e-11  # Z7
+                      -  2.339e-10  # Z8
+                      - -2.672e-08  # Z9
+                      -  5.589e-09  # Z10
+                      - -5.035e-08  # Z11
+                      - -3.938e-08  # Z12
+                      -  2.980e-08  # Z13
+                      - -1.081e-08  # Z14
+                      -  6.656e-08  # Z15
+                      - -1.349e-09  # Z16
+                      -  2.140e-08  # Z17
+                      - -7.021e-08  # Z18
+                      -  3.506e-08  # Z19
+                      -  4.311e-08  # Z20
+                      -  1.115e-09  # Z21
+                      -  6.493e-08  # Z22
+                      -  1.522e-08  # Z23
+                      - -4.074e-08  # Z24
+                      -  9.145e-09  # Z25
+                      -  1.094e-08  # Z26
+                      - -9.351e-08  # Z27
+                      - -1.639e-07  # Z28
+              obscuration:
+                type: ClearCircle
+                radius: 0.375
+            -
+              type: RefractiveInterface
+              name: Filter_exit
+              surface:
+                type: Sphere
+                R: 5.623000321  # 1/CRVT from multi-configuration
+              obscuration:
+                type: ClearCircle
+                radius: 0.375
+              coordSys:
+                z: 0.0157  # THIC from multi-configuration
+        -
+          type: Lens
+          name: L3
+          medium: *silica
+          coordSys:
+            x: -1.7867810238809937e-04
+            y: -2.7620000000000010e-04
+            z: 9.4308838924627658e-01
+            rotY: -7.5049157835756176e-05
+          items:
+            -
+              type: RefractiveInterface
+              name: L3_entrance
+              surface:
+                type: Quadric
+                R: 3.169       # 1/CURV
+                conic: -0.962  # CONI
+              obscuration:
+                type: ClearCircle
+                radius: 0.361
+            -
+              type: RefractiveInterface
+              name: L3_exit
+              surface:
+                type: Sphere
+                R: -13.36   # 1/CURV
+              obscuration:
+                type: ClearCircle
+                radius: 0.361
+              coordSys:
+                z: 0.06008  #DISZ
+        -
+          type: Detector
+          name: Detector
+          surface:
+            type: Plane
+          obscuration:
+            type: ClearCircle
+            radius: 0.4
+          coordSys:
+            # accumulated transforms
+            x: -1.8535755247836943e-04
+            y: -2.7619999999999988e-04
+            z: 1.0320893889956335e+00
+            rotX: -2.0064305269723316e-04
+            rotY: -1.3718287644542526e-04
+            rotZ: -2.7524791390826322e-08

--- a/batoid/data/LSST/Rubin_v1000_r.yaml
+++ b/batoid/data/LSST/Rubin_v1000_r.yaml
@@ -1,0 +1,372 @@
+# Add M1, M1M3, and inner hole baffles from priv comm with R. Tighe.
+# We'll add the M1 baffle as a separate optic.  But for the M1M3 Baffle
+# and inner hole baffle we'll just change the obscuration for M1 and M3
+# directly.
+# Also adjust the entrance pupil to match the M1 Baffle.
+
+opticalSystem:
+  type: CompoundOptic
+  name: LSST
+  inMedium: &vacuum 1.0
+  medium: *vacuum
+  backDist: 15.0  # distance from global vertex to use to start tracing rays
+  sphereRadius: 5.0  # reference sphere radius to use for wavefront calculation
+  pupilSize: 8.33  # Pupil fits inside a square with this side length
+  pupilObscuration: 0.612  # Fractional pupil central obscuration
+  stopSurface:
+    type: Interface
+    name: entrancePupil
+    surface:
+      type: Plane
+    coordSys:
+      z: 0.48283
+  items:
+    -
+      type: Baffle
+      name: M1Baffle1
+      surface:
+        type: Plane
+      obscuration:
+        type: ClearCircle
+        radius: 4.165
+      coordSys:
+        z: 0.48283
+    -
+      type: Mirror
+      name: M1
+      surface:
+        type: Asphere
+        R: 19.8346                # 1/CURV
+        conic: -1.21502           # CONI
+        coefs: [0.0, -1.381e-9]   # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 4.18
+        inner: 2.5833  # R. Tighe. priv comm
+    -
+      type: Baffle
+      name: M1Baffle2
+      surface:
+        type: Plane
+      obscuration:
+        type: ClearCircle
+        radius: 4.165
+      coordSys:
+        z: 0.48283
+    -
+      type: Mirror
+      name: M2
+      surface:
+        type: Asphere
+        R: 6.79005                # 1/CURV
+        conic: -0.222             # CONI
+        coefs: [0.0, 1.274e-5, 9.68e-7] # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 1.71
+        inner: 0.9
+      coordSys:
+        # From COORDBRK
+        x: -2.2999986825621125e-05
+        y:  1.300002205197993e-05
+        z: 6.15535506215  # CUMSUM of DISZ
+        rotX: 1.016654289286697e-05  # -np.deg2rad(-0.0005825)
+        rotY: -6.073745796940267e-06  # np.deg2rad(-0.000348)
+    -
+      type: Baffle
+      name: CameraBody
+      parent: LSSTCamera  # physically attached to camera; moves with it under rigid-body ops
+      surface:
+        type: Plane
+      obscuration:
+        type: ObscCircle
+        radius: 0.80469  # = 1.60938/2 m; camera body outer diameter
+      coordSys:
+        x: -0.0009089130556575664
+        y: -0.00023347981008824386
+        z: 3.5002366333710864
+        rotX: 0.00013010556419248287
+        rotY: 0.0001844974335291165
+        rotZ: -1.4239829750999484e-08
+    -
+      type: Mirror
+      name: M3
+      surface:
+        type: Asphere
+        R: 8.3439       # 1/CURV
+        conic: 0.15497  # CONI
+        coefs: [0.0, 4.5e-7, 8.15e-9]  # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 2.48511  # R. Tighe. priv comm
+        inner: 0.52735  # R. Tighe. priv comm
+      coordSys:
+        # From accumulated coordinate transforms
+        x: -3.6299998682604528e-04
+        y: -1.6899997794876846e-04
+        z: -2.3439999999999817e-01
+        rotX: -2.3387411999344819e-05
+        rotY: 4.3982297138228580e-05
+    -
+      type: CompoundOptic
+      name: LSSTCamera
+      coordSys:
+        # accumulated transforms
+        x: -9.2819303735197948e-04
+        y: -2.1988377889988682e-04
+        z: 3.3957366360340995e+00
+        rotX: 1.3010556419248284e-04
+        rotY: 1.8449743352911649e-04
+        rotZ: -1.4239829750999484e-08
+      items:
+        -
+          type: Lens
+          name: L1
+          medium: &silica
+            # from fitting Sellmeier coefs to [ugriz]_prescription index data
+            type: SellmeierMedium
+            B1: 0.6961829842616872
+            B2: 0.4079259129074905
+            B3: 0.8974643319456314
+            C1: 0.004679264915537484
+            C2: 0.013512224089229979
+            C3: 97.93239315034683
+          items:
+            -
+              type: RefractiveInterface
+              name: L1_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: 2.823354  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.775
+                    # To convert Zemax -> batoid, need to flip x, y, z => -x, y, -z
+                    # Amounts to flipping signs of
+                    # Z1, Z3, Z4, Z6, Z7, Z9, Z11, Z12, Z14, Z17, Z19, Z21, Z22, Z24, Z26, Z28
+                    coef:
+                      -  0.0
+                      - -5.099E-10  # Z1
+                      -  9.089E-11  # Z2
+                      -  2.151E-10  # Z3
+                      -  4.171E-08  # Z4
+                      -  4.549E-09  # Z5
+                      - -3.728E-08  # Z6
+                      -  1.441E-08  # Z7
+                      -  1.791E-08  # Z8
+                      -  3.841E-09  # Z9
+                      - -1.684E-08  # Z10
+                      - -3.002E-08  # Z11
+                      - -1.249E-08  # Z12
+                      - -4.490E-09  # Z13
+                      - -7.715E-09  # Z14
+                      -  1.197E-09  # Z15
+                      -  7.780E-09  # Z16
+                      - -1.189E-08  # Z17
+                      - -1.902E-09  # Z18
+                      -  5.311E-09  # Z19
+                      - -5.026E-09  # Z20
+                      -  8.985E-09  # Z21
+                      - -1.321E-08  # Z22
+                      - -7.393E-09  # Z23
+                      - -9.319E-09  # Z24
+                      - -3.555E-09  # Z25
+                      - -5.699E-09  # Z26
+                      - -7.704E-09  # Z27
+                      - -1.860E-08  # Z28
+              obscuration:
+                type: ClearCircle
+                radius: 0.775
+            -
+              type: RefractiveInterface
+              name: L1_exit
+              surface:
+                type: Sphere
+                R: 5.018956  # 1/CURV
+              obscuration:
+                type: ClearCircle
+                radius: 0.775
+              coordSys:
+                z: 0.08231  # DISZ
+        -
+          type: Lens
+          name: L2
+          medium: *silica
+          coordSys:
+            z: 0.494881  # cumsum of some DISZ, checked against global vertex coord
+          items:
+            -
+              type: RefractiveInterface
+              name: L2_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: -48040.0  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.551
+                    coef:
+                      - -0.0
+                      -  8.408e-09
+                      -  1.927e-09
+                      -  1.502e-09
+                      - -4.473e-08
+                      -  2.731e-09
+                      -  6.184e-08
+                      -  1.834e-09
+                      -  2.354e-09
+                      - -3.440e-08
+                      - -1.255e-08
+                      -  5.409e-08
+                      -  7.787e-09
+                      - -3.49e-09
+                      - -1.172e-09
+                      - -4.626e-09
+                      -  4.564e-09
+                      -  3.556e-09
+                      -  3.987e-09
+                      -  5.803e-09
+                      - -2.950e-09
+                      -  2.986e-09
+                      -  4.575e-08
+                      - -9.143e-10
+                      - -5.526e-10
+                      - -4.372e-09
+                      - -5.158e-10
+                      -  1.471e-09
+                      -  1.916e-09
+              obscuration:
+                type: ClearCircle
+                radius: 0.551
+            -
+              type: RefractiveInterface
+              name: L2_exit
+              surface:
+                type: Asphere
+                R: 2.5291       # 1/CURV
+                conic: -1.57    # CONI
+                coefs: [0.0, -0.001656]  # PARM
+              obscuration:
+                type: ClearCircle
+                radius: 0.551
+              coordSys:
+                z: 0.03005
+        -
+          type: Lens
+          name: Filter
+          medium: *silica
+          coordSys:
+            # accumulated transforms
+            x: -1.7328056696161860e-04
+            y: -2.7620000000000005e-04
+            z: 8.7116838944881725e-01
+            rotY: -7.5049157835756176e-05
+          items:
+            -
+              type: RefractiveInterface
+              name: Filter_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: 5.632  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.378
+                    coef:
+                      -  0.0
+                      - -9.908e-10  # Z1
+                      -  1.208e-10  # Z2
+                      - -1.371e-10  # Z3
+                      - -1.669e-08  # Z4
+                      - -5.983e-08  # Z5
+                      -  1.833e-08  # Z6
+                      -  2.277e-08  # Z7
+                      - -1.498e-08  # Z8
+                      - -1.568e-08  # Z9
+                      -  1.310e-08  # Z10
+                      -  7.353e-08  # Z11
+                      -  1.701e-08  # Z12
+                      -  4.004e-09  # Z13
+                      -  2.868e-09  # Z14
+                      - -1.982e-09  # Z15
+                      - -6.538e-09  # Z16
+                      -  1.761e-08  # Z17
+                      -  1.260e-09  # Z18
+                      - -1.721e-08  # Z19
+                      - -1.268e-08  # Z20
+                      -  3.981e-11  # Z21
+                      -  1.097e-07  # Z22
+                      -  1.178e-08  # Z23
+                      -  2.006e-08  # Z24
+                      -  9.898e-10  # Z25
+                      - -7.154e-09  # Z26
+                      - -3.935e-08  # Z27
+                      -  1.517e-08  # Z28
+              obscuration:
+                type: ClearCircle
+                radius: 0.375
+            -
+              type: RefractiveInterface
+              name: Filter_exit
+              surface:
+                type: Sphere
+                R: 5.606  # 1/CRVT from multi-configuration
+              obscuration:
+                type: ClearCircle
+                radius: 0.375
+              coordSys:
+                z: 0.0179  # THIC from multi-configuration
+        -
+          type: Lens
+          name: L3
+          medium: *silica
+          coordSys:
+            x: -1.7867810238809937e-04
+            y: -2.7620000000000010e-04
+            z: 9.4308838924627658e-01
+            rotY: -7.5049157835756176e-05
+          items:
+            -
+              type: RefractiveInterface
+              name: L3_entrance
+              surface:
+                type: Quadric
+                R: 3.169       # 1/CURV
+                conic: -0.962  # CONI
+              obscuration:
+                type: ClearCircle
+                radius: 0.361
+            -
+              type: RefractiveInterface
+              name: L3_exit
+              surface:
+                type: Sphere
+                R: -13.36   # 1/CURV
+              obscuration:
+                type: ClearCircle
+                radius: 0.361
+              coordSys:
+                z: 0.06008  #DISZ
+        -
+          type: Detector
+          name: Detector
+          surface:
+            type: Plane
+          obscuration:
+            type: ClearCircle
+            radius: 0.4
+          coordSys:
+            # accumulated transforms
+            x: -1.8535755247836943e-04
+            y: -2.7619999999999988e-04
+            z: 1.0320893889956335e+00
+            rotX: -2.0064305269723316e-04
+            rotY: -1.3718287644542526e-04
+            rotZ: -2.7524791390826322e-08

--- a/batoid/data/LSST/Rubin_v1000_u.yaml
+++ b/batoid/data/LSST/Rubin_v1000_u.yaml
@@ -1,0 +1,337 @@
+# Add M1, M1M3, and inner hole baffles from priv comm with R. Tighe.
+# We'll add the M1 baffle as a separate optic.  But for the M1M3 Baffle
+# and inner hole baffle we'll just change the obscuration for M1 and M3
+# directly.
+# Also adjust the entrance pupil to match the M1 Baffle.
+
+opticalSystem:
+  type: CompoundOptic
+  name: LSST
+  inMedium: &vacuum 1.0
+  medium: *vacuum
+  backDist: 15.0  # distance from global vertex to use to start tracing rays
+  sphereRadius: 5.0  # reference sphere radius to use for wavefront calculation
+  pupilSize: 8.33  # Pupil fits inside a square with this side length
+  pupilObscuration: 0.612  # Fractional pupil central obscuration
+  stopSurface:
+    type: Interface
+    name: entrancePupil
+    surface:
+      type: Plane
+    coordSys:
+      z: 0.48283
+  items:
+    -
+      type: Baffle
+      name: M1Baffle1
+      surface:
+        type: Plane
+      obscuration:
+        type: ClearCircle
+        radius: 4.165
+      coordSys:
+        z: 0.48283
+    -
+      type: Mirror
+      name: M1
+      surface:
+        type: Asphere
+        R: 19.8346                # 1/CURV
+        conic: -1.21502           # CONI
+        coefs: [0.0, -1.381e-9]   # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 4.18
+        inner: 2.5833  # R. Tighe. priv comm
+    -
+      type: Baffle
+      name: M1Baffle2
+      surface:
+        type: Plane
+      obscuration:
+        type: ClearCircle
+        radius: 4.165
+      coordSys:
+        z: 0.48283
+    -
+      type: Mirror
+      name: M2
+      surface:
+        type: Asphere
+        R: 6.79005                # 1/CURV
+        conic: -0.222             # CONI
+        coefs: [0.0, 1.274e-5, 9.68e-7] # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 1.71
+        inner: 0.9
+      coordSys:
+        # From COORDBRK
+        x: -2.2999986825621125e-05
+        y:  1.300002205197993e-05
+        z: 6.15535506215  # CUMSUM of DISZ
+        rotX: 1.016654289286697e-05  # -np.deg2rad(-0.0005825)
+        rotY: -6.073745796940267e-06  # np.deg2rad(-0.000348)
+    -
+      type: Baffle
+      name: CameraBody
+      parent: LSSTCamera  # physically attached to camera; moves with it under rigid-body ops
+      surface:
+        type: Plane
+      obscuration:
+        type: ObscCircle
+        radius: 0.80469  # = 1.60938/2 m; camera body outer diameter
+      coordSys:
+        x: -0.0009089130556575664
+        y: -0.00023347981008824386
+        z: 3.5030296333710864
+        rotX: 0.00013010556419248287
+        rotY: 0.0001844974335291165
+        rotZ: -1.4239829750999484e-08
+    -
+      type: Mirror
+      name: M3
+      surface:
+        type: Asphere
+        R: 8.3439       # 1/CURV
+        conic: 0.15497  # CONI
+        coefs: [0.0, 4.5e-7, 8.15e-9]  # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 2.48511  # R. Tighe. priv comm
+        inner: 0.52735  # R. Tighe. priv comm
+      coordSys:
+        # From accumulated coordinate transforms
+        x: -3.6299998682604528e-04
+        y: -1.6899997794876846e-04
+        z: -2.3439999999999817e-01
+        rotX: -2.3387411999344819e-05
+        rotY: 4.3982297138228580e-05
+    -
+      type: CompoundOptic
+      name: LSSTCamera
+      coordSys:
+        # accumulated transforms
+        x: -9.2819303735197948e-04
+        y: -2.1988377889988682e-04
+        z: 3.3985296360340995e+00
+        rotX: 1.3010556419248284e-04
+        rotY: 1.8449743352911649e-04
+        rotZ: -1.4239829750999484e-08
+      items:
+        -
+          type: Lens
+          name: L1
+          medium: &silica
+            # from fitting Sellmeier coefs to [ugriz]_prescription index data
+            type: SellmeierMedium
+            B1: 0.6961829842616872
+            B2: 0.4079259129074905
+            B3: 0.8974643319456314
+            C1: 0.004679264915537484
+            C2: 0.013512224089229979
+            C3: 97.93239315034683
+          items:
+            -
+              type: RefractiveInterface
+              name: L1_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: 2.823354  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.775
+                    # To convert Zemax -> batoid, need to flip x, y, z => -x, y, -z
+                    # Amounts to flipping signs of
+                    # Z1, Z3, Z4, Z6, Z7, Z9, Z11, Z12, Z14, Z17, Z19, Z21, Z22, Z24, Z26, Z28
+                    coef:
+                      -  0.0
+                      - -5.099E-10  # Z1
+                      -  9.089E-11  # Z2
+                      -  2.151E-10  # Z3
+                      -  4.171E-08  # Z4
+                      -  4.549E-09  # Z5
+                      - -3.728E-08  # Z6
+                      -  1.441E-08  # Z7
+                      -  1.791E-08  # Z8
+                      -  3.841E-09  # Z9
+                      - -1.684E-08  # Z10
+                      - -3.002E-08  # Z11
+                      - -1.249E-08  # Z12
+                      - -4.490E-09  # Z13
+                      - -7.715E-09  # Z14
+                      -  1.197E-09  # Z15
+                      -  7.780E-09  # Z16
+                      - -1.189E-08  # Z17
+                      - -1.902E-09  # Z18
+                      -  5.311E-09  # Z19
+                      - -5.026E-09  # Z20
+                      -  8.985E-09  # Z21
+                      - -1.321E-08  # Z22
+                      - -7.393E-09  # Z23
+                      - -9.319E-09  # Z24
+                      - -3.555E-09  # Z25
+                      - -5.699E-09  # Z26
+                      - -7.704E-09  # Z27
+                      - -1.860E-08  # Z28
+              obscuration:
+                type: ClearCircle
+                radius: 0.775
+            -
+              type: RefractiveInterface
+              name: L1_exit
+              surface:
+                type: Sphere
+                R: 5.018956  # 1/CURV
+              obscuration:
+                type: ClearCircle
+                radius: 0.775
+              coordSys:
+                z: 0.08231  # DISZ
+        -
+          type: Lens
+          name: L2
+          medium: *silica
+          coordSys:
+            z: 0.494881  # cumsum of some DISZ, checked against global vertex coord
+          items:
+            -
+              type: RefractiveInterface
+              name: L2_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: -48040.0  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.551
+                    coef:
+                      - -0.0
+                      -  8.408e-09
+                      -  1.927e-09
+                      -  1.502e-09
+                      - -4.473e-08
+                      -  2.731e-09
+                      -  6.184e-08
+                      -  1.834e-09
+                      -  2.354e-09
+                      - -3.440e-08
+                      - -1.255e-08
+                      -  5.409e-08
+                      -  7.787e-09
+                      - -3.49e-09
+                      - -1.172e-09
+                      - -4.626e-09
+                      -  4.564e-09
+                      -  3.556e-09
+                      -  3.987e-09
+                      -  5.803e-09
+                      - -2.950e-09
+                      -  2.986e-09
+                      -  4.575e-08
+                      - -9.143e-10
+                      - -5.526e-10
+                      - -4.372e-09
+                      - -5.158e-10
+                      -  1.471e-09
+                      -  1.916e-09
+              obscuration:
+                type: ClearCircle
+                radius: 0.551
+            -
+              type: RefractiveInterface
+              name: L2_exit
+              surface:
+                type: Asphere
+                R: 2.5291       # 1/CURV
+                conic: -1.57    # CONI
+                coefs: [0.0, -0.001656]  # PARM
+              obscuration:
+                type: ClearCircle
+                radius: 0.551
+              coordSys:
+                z: 0.03005
+        -
+          type: Lens
+          name: Filter
+          medium: *silica
+          coordSys:
+            # accumulated transforms
+            x: -1.7328056696161860e-04
+            y: -2.7620000000000005e-04
+            z: 8.7116838944881725e-01
+            rotY: -7.5049157835756176e-05
+          items:
+            -
+              type: RefractiveInterface
+              name: Filter_entrance
+              surface:
+                type: Sphere
+                R: 5.632  # 1/CURV
+                # Note: For r and i band, read Zernike coefficients from multi-config data.
+              obscuration:
+                type: ClearCircle
+                radius: 0.375
+            -
+              type: RefractiveInterface
+              name: Filter_exit
+              surface:
+                type: Sphere
+                R: 5.530  # 1/CRVT from multi-configuration
+              obscuration:
+                type: ClearCircle
+                radius: 0.375
+              coordSys:
+                z: 0.0266  # THIC from multi-configuration
+        -
+          type: Lens
+          name: L3
+          medium: *silica
+          coordSys:
+            x: -1.7867810238809937e-04
+            y: -2.7620000000000010e-04
+            z: 9.4308838924627658e-01
+            rotY: -7.5049157835756176e-05
+          items:
+            -
+              type: RefractiveInterface
+              name: L3_entrance
+              surface:
+                type: Quadric
+                R: 3.169       # 1/CURV
+                conic: -0.962  # CONI
+              obscuration:
+                type: ClearCircle
+                radius: 0.361
+            -
+              type: RefractiveInterface
+              name: L3_exit
+              surface:
+                type: Sphere
+                R: -13.36   # 1/CURV
+              obscuration:
+                type: ClearCircle
+                radius: 0.361
+              coordSys:
+                z: 0.06008  #DISZ
+        -
+          type: Detector
+          name: Detector
+          surface:
+            type: Plane
+          obscuration:
+            type: ClearCircle
+            radius: 0.4
+          coordSys:
+            # accumulated transforms
+            x: -1.8535755247836943e-04
+            y: -2.7619999999999988e-04
+            z: 1.0320893889956335e+00
+            rotX: -2.0064305269723316e-04
+            rotY: -1.3718287644542526e-04
+            rotZ: -2.7524791390826322e-08

--- a/batoid/data/LSST/Rubin_v1000_y.yaml
+++ b/batoid/data/LSST/Rubin_v1000_y.yaml
@@ -1,0 +1,337 @@
+# Add M1, M1M3, and inner hole baffles from priv comm with R. Tighe.
+# We'll add the M1 baffle as a separate optic.  But for the M1M3 Baffle
+# and inner hole baffle we'll just change the obscuration for M1 and M3
+# directly.
+# Also adjust the entrance pupil to match the M1 Baffle.
+
+opticalSystem:
+  type: CompoundOptic
+  name: LSST
+  inMedium: &vacuum 1.0
+  medium: *vacuum
+  backDist: 15.0  # distance from global vertex to use to start tracing rays
+  sphereRadius: 5.0  # reference sphere radius to use for wavefront calculation
+  pupilSize: 8.33  # Pupil fits inside a square with this side length
+  pupilObscuration: 0.612  # Fractional pupil central obscuration
+  stopSurface:
+    type: Interface
+    name: entrancePupil
+    surface:
+      type: Plane
+    coordSys:
+      z: 0.48283
+  items:
+    -
+      type: Baffle
+      name: M1Baffle1
+      surface:
+        type: Plane
+      obscuration:
+        type: ClearCircle
+        radius: 4.165
+      coordSys:
+        z: 0.48283
+    -
+      type: Mirror
+      name: M1
+      surface:
+        type: Asphere
+        R: 19.8346                # 1/CURV
+        conic: -1.21502           # CONI
+        coefs: [0.0, -1.381e-9]   # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 4.18
+        inner: 2.5833  # R. Tighe. priv comm
+    -
+      type: Baffle
+      name: M1Baffle2
+      surface:
+        type: Plane
+      obscuration:
+        type: ClearCircle
+        radius: 4.165
+      coordSys:
+        z: 0.48283
+    -
+      type: Mirror
+      name: M2
+      surface:
+        type: Asphere
+        R: 6.79005                # 1/CURV
+        conic: -0.222             # CONI
+        coefs: [0.0, 1.274e-5, 9.68e-7] # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 1.71
+        inner: 0.9
+      coordSys:
+        # From COORDBRK
+        x: -2.2999986825621125e-05
+        y:  1.300002205197993e-05
+        z: 6.15535506215  # CUMSUM of DISZ
+        rotX: 1.016654289286697e-05  # -np.deg2rad(-0.0005825)
+        rotY: -6.073745796940267e-06  # np.deg2rad(-0.000348)
+    -
+      type: Baffle
+      name: CameraBody
+      parent: LSSTCamera  # physically attached to camera; moves with it under rigid-body ops
+      surface:
+        type: Plane
+      obscuration:
+        type: ObscCircle
+        radius: 0.80469  # = 1.60938/2 m; camera body outer diameter
+      coordSys:
+        x: -0.0009089130556575664
+        y: -0.00023347981008824386
+        z: 3.498894031860467
+        rotX: 0.00013010556419248287
+        rotY: 0.0001844974335291165
+        rotZ: -1.4239829750999484e-08
+    -
+      type: Mirror
+      name: M3
+      surface:
+        type: Asphere
+        R: 8.3439       # 1/CURV
+        conic: 0.15497  # CONI
+        coefs: [0.0, 4.5e-7, 8.15e-9]  # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 2.48511  # R. Tighe. priv comm
+        inner: 0.52735  # R. Tighe. priv comm
+      coordSys:
+        # From accumulated coordinate transforms
+        x: -3.6299998682604528e-04
+        y: -1.6899997794876846e-04
+        z: -2.3439999999999817e-01
+        rotX: -2.3387411999344819e-05
+        rotY: 4.3982297138228580e-05
+    -
+      type: CompoundOptic
+      name: LSSTCamera
+      coordSys:
+        # accumulated transforms
+        x: -9.2819303735197948e-04
+        y: -2.1988377889988682e-04
+        z: 3.3943940345234802e+00
+        rotX: 1.3010556419248284e-04
+        rotY: 1.8449743352911649e-04
+        rotZ: -1.4239829750999484e-08
+      items:
+        -
+          type: Lens
+          name: L1
+          medium: &silica
+            # from fitting Sellmeier coefs to [ugriz]_prescription index data
+            type: SellmeierMedium
+            B1: 0.6961829842616872
+            B2: 0.4079259129074905
+            B3: 0.8974643319456314
+            C1: 0.004679264915537484
+            C2: 0.013512224089229979
+            C3: 97.93239315034683
+          items:
+            -
+              type: RefractiveInterface
+              name: L1_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: 2.823354  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.775
+                    # To convert Zemax -> batoid, need to flip x, y, z => -x, y, -z
+                    # Amounts to flipping signs of
+                    # Z1, Z3, Z4, Z6, Z7, Z9, Z11, Z12, Z14, Z17, Z19, Z21, Z22, Z24, Z26, Z28
+                    coef:
+                      -  0.0
+                      - -5.099E-10  # Z1
+                      -  9.089E-11  # Z2
+                      -  2.151E-10  # Z3
+                      -  4.171E-08  # Z4
+                      -  4.549E-09  # Z5
+                      - -3.728E-08  # Z6
+                      -  1.441E-08  # Z7
+                      -  1.791E-08  # Z8
+                      -  3.841E-09  # Z9
+                      - -1.684E-08  # Z10
+                      - -3.002E-08  # Z11
+                      - -1.249E-08  # Z12
+                      - -4.490E-09  # Z13
+                      - -7.715E-09  # Z14
+                      -  1.197E-09  # Z15
+                      -  7.780E-09  # Z16
+                      - -1.189E-08  # Z17
+                      - -1.902E-09  # Z18
+                      -  5.311E-09  # Z19
+                      - -5.026E-09  # Z20
+                      -  8.985E-09  # Z21
+                      - -1.321E-08  # Z22
+                      - -7.393E-09  # Z23
+                      - -9.319E-09  # Z24
+                      - -3.555E-09  # Z25
+                      - -5.699E-09  # Z26
+                      - -7.704E-09  # Z27
+                      - -1.860E-08  # Z28
+              obscuration:
+                type: ClearCircle
+                radius: 0.775
+            -
+              type: RefractiveInterface
+              name: L1_exit
+              surface:
+                type: Sphere
+                R: 5.018956  # 1/CURV
+              obscuration:
+                type: ClearCircle
+                radius: 0.775
+              coordSys:
+                z: 0.08231  # DISZ
+        -
+          type: Lens
+          name: L2
+          medium: *silica
+          coordSys:
+            z: 0.494881  # cumsum of some DISZ, checked against global vertex coord
+          items:
+            -
+              type: RefractiveInterface
+              name: L2_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: -48040.0  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.551
+                    coef:
+                      - -0.0
+                      -  8.408e-09
+                      -  1.927e-09
+                      -  1.502e-09
+                      - -4.473e-08
+                      -  2.731e-09
+                      -  6.184e-08
+                      -  1.834e-09
+                      -  2.354e-09
+                      - -3.440e-08
+                      - -1.255e-08
+                      -  5.409e-08
+                      -  7.787e-09
+                      - -3.49e-09
+                      - -1.172e-09
+                      - -4.626e-09
+                      -  4.564e-09
+                      -  3.556e-09
+                      -  3.987e-09
+                      -  5.803e-09
+                      - -2.950e-09
+                      -  2.986e-09
+                      -  4.575e-08
+                      - -9.143e-10
+                      - -5.526e-10
+                      - -4.372e-09
+                      - -5.158e-10
+                      -  1.471e-09
+                      -  1.916e-09
+              obscuration:
+                type: ClearCircle
+                radius: 0.551
+            -
+              type: RefractiveInterface
+              name: L2_exit
+              surface:
+                type: Asphere
+                R: 2.5291       # 1/CURV
+                conic: -1.57    # CONI
+                coefs: [0.0, -0.001656]  # PARM
+              obscuration:
+                type: ClearCircle
+                radius: 0.551
+              coordSys:
+                z: 0.03005
+        -
+          type: Lens
+          name: Filter
+          medium: *silica
+          coordSys:
+            # accumulated transforms
+            x: -1.7328056696161860e-04
+            y: -2.7620000000000005e-04
+            z: 8.7116838944881725e-01
+            rotY: -7.5049157835756176e-05
+          items:
+            -
+              type: RefractiveInterface
+              name: Filter_entrance
+              surface:
+                type: Sphere
+                R: 5.632  # 1/CURV
+                # Note: For r and i band, read Zernike coefficients from multi-config data.
+              obscuration:
+                type: ClearCircle
+                radius: 0.375
+            -
+              type: RefractiveInterface
+              name: Filter_exit
+              surface:
+                type: Sphere
+                R: 5.640  # 1/CRVT from multi-configuration
+              obscuration:
+                type: ClearCircle
+                radius: 0.375
+              coordSys:
+                z: 0.0136  # THIC from multi-configuration
+        -
+          type: Lens
+          name: L3
+          medium: *silica
+          coordSys:
+            x: -1.7867810238809937e-04
+            y: -2.7620000000000010e-04
+            z: 9.4308838924627658e-01
+            rotY: -7.5049157835756176e-05
+          items:
+            -
+              type: RefractiveInterface
+              name: L3_entrance
+              surface:
+                type: Quadric
+                R: 3.169       # 1/CURV
+                conic: -0.962  # CONI
+              obscuration:
+                type: ClearCircle
+                radius: 0.361
+            -
+              type: RefractiveInterface
+              name: L3_exit
+              surface:
+                type: Sphere
+                R: -13.36   # 1/CURV
+              obscuration:
+                type: ClearCircle
+                radius: 0.361
+              coordSys:
+                z: 0.06008  #DISZ
+        -
+          type: Detector
+          name: Detector
+          surface:
+            type: Plane
+          obscuration:
+            type: ClearCircle
+            radius: 0.4
+          coordSys:
+            # accumulated transforms
+            x: -1.8535755247836943e-04
+            y: -2.7619999999999988e-04
+            z: 1.0320893889956335e+00
+            rotX: -2.0064305269723316e-04
+            rotY: -1.3718287644542526e-04
+            rotZ: -2.7524791390826322e-08

--- a/batoid/data/LSST/Rubin_v1000_z.yaml
+++ b/batoid/data/LSST/Rubin_v1000_z.yaml
@@ -1,0 +1,337 @@
+# Add M1, M1M3, and inner hole baffles from priv comm with R. Tighe.
+# We'll add the M1 baffle as a separate optic.  But for the M1M3 Baffle
+# and inner hole baffle we'll just change the obscuration for M1 and M3
+# directly.
+# Also adjust the entrance pupil to match the M1 Baffle.
+
+opticalSystem:
+  type: CompoundOptic
+  name: LSST
+  inMedium: &vacuum 1.0
+  medium: *vacuum
+  backDist: 15.0  # distance from global vertex to use to start tracing rays
+  sphereRadius: 5.0  # reference sphere radius to use for wavefront calculation
+  pupilSize: 8.33  # Pupil fits inside a square with this side length
+  pupilObscuration: 0.612  # Fractional pupil central obscuration
+  stopSurface:
+    type: Interface
+    name: entrancePupil
+    surface:
+      type: Plane
+    coordSys:
+      z: 0.48283
+  items:
+    -
+      type: Baffle
+      name: M1Baffle1
+      surface:
+        type: Plane
+      obscuration:
+        type: ClearCircle
+        radius: 4.165
+      coordSys:
+        z: 0.48283
+    -
+      type: Mirror
+      name: M1
+      surface:
+        type: Asphere
+        R: 19.8346                # 1/CURV
+        conic: -1.21502           # CONI
+        coefs: [0.0, -1.381e-9]   # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 4.18
+        inner: 2.5833  # R. Tighe. priv comm
+    -
+      type: Baffle
+      name: M1Baffle2
+      surface:
+        type: Plane
+      obscuration:
+        type: ClearCircle
+        radius: 4.165
+      coordSys:
+        z: 0.48283
+    -
+      type: Mirror
+      name: M2
+      surface:
+        type: Asphere
+        R: 6.79005                # 1/CURV
+        conic: -0.222             # CONI
+        coefs: [0.0, 1.274e-5, 9.68e-7] # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 1.71
+        inner: 0.9
+      coordSys:
+        # From COORDBRK
+        x: -2.2999986825621125e-05
+        y:  1.300002205197993e-05
+        z: 6.15535506215  # CUMSUM of DISZ
+        rotX: 1.016654289286697e-05  # -np.deg2rad(-0.0005825)
+        rotY: -6.073745796940267e-06  # np.deg2rad(-0.000348)
+    -
+      type: Baffle
+      name: CameraBody
+      parent: LSSTCamera  # physically attached to camera; moves with it under rigid-body ops
+      surface:
+        type: Plane
+      obscuration:
+        type: ObscCircle
+        radius: 0.80469  # = 1.60938/2 m; camera body outer diameter
+      coordSys:
+        x: -0.0009089130556575664
+        y: -0.00023347981008824386
+        z: 3.4991431119092002
+        rotX: 0.00013010556419248287
+        rotY: 0.0001844974335291165
+        rotZ: -1.4239829750999484e-08
+    -
+      type: Mirror
+      name: M3
+      surface:
+        type: Asphere
+        R: 8.3439       # 1/CURV
+        conic: 0.15497  # CONI
+        coefs: [0.0, 4.5e-7, 8.15e-9]  # PARM
+      obscuration:
+        type: ClearAnnulus
+        outer: 2.48511  # R. Tighe. priv comm
+        inner: 0.52735  # R. Tighe. priv comm
+      coordSys:
+        # From accumulated coordinate transforms
+        x: -3.6299998682604528e-04
+        y: -1.6899997794876846e-04
+        z: -2.3439999999999817e-01
+        rotX: -2.3387411999344819e-05
+        rotY: 4.3982297138228580e-05
+    -
+      type: CompoundOptic
+      name: LSSTCamera
+      coordSys:
+        # accumulated transforms
+        x: -9.2819303735197948e-04
+        y: -2.1988377889988682e-04
+        z: 3.3946431145722133e+00
+        rotX: 1.3010556419248284e-04
+        rotY: 1.8449743352911649e-04
+        rotZ: -1.4239829750999484e-08
+      items:
+        -
+          type: Lens
+          name: L1
+          medium: &silica
+            # from fitting Sellmeier coefs to [ugriz]_prescription index data
+            type: SellmeierMedium
+            B1: 0.6961829842616872
+            B2: 0.4079259129074905
+            B3: 0.8974643319456314
+            C1: 0.004679264915537484
+            C2: 0.013512224089229979
+            C3: 97.93239315034683
+          items:
+            -
+              type: RefractiveInterface
+              name: L1_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: 2.823354  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.775
+                    # To convert Zemax -> batoid, need to flip x, y, z => -x, y, -z
+                    # Amounts to flipping signs of
+                    # Z1, Z3, Z4, Z6, Z7, Z9, Z11, Z12, Z14, Z17, Z19, Z21, Z22, Z24, Z26, Z28
+                    coef:
+                      -  0.0
+                      - -5.099E-10  # Z1
+                      -  9.089E-11  # Z2
+                      -  2.151E-10  # Z3
+                      -  4.171E-08  # Z4
+                      -  4.549E-09  # Z5
+                      - -3.728E-08  # Z6
+                      -  1.441E-08  # Z7
+                      -  1.791E-08  # Z8
+                      -  3.841E-09  # Z9
+                      - -1.684E-08  # Z10
+                      - -3.002E-08  # Z11
+                      - -1.249E-08  # Z12
+                      - -4.490E-09  # Z13
+                      - -7.715E-09  # Z14
+                      -  1.197E-09  # Z15
+                      -  7.780E-09  # Z16
+                      - -1.189E-08  # Z17
+                      - -1.902E-09  # Z18
+                      -  5.311E-09  # Z19
+                      - -5.026E-09  # Z20
+                      -  8.985E-09  # Z21
+                      - -1.321E-08  # Z22
+                      - -7.393E-09  # Z23
+                      - -9.319E-09  # Z24
+                      - -3.555E-09  # Z25
+                      - -5.699E-09  # Z26
+                      - -7.704E-09  # Z27
+                      - -1.860E-08  # Z28
+              obscuration:
+                type: ClearCircle
+                radius: 0.775
+            -
+              type: RefractiveInterface
+              name: L1_exit
+              surface:
+                type: Sphere
+                R: 5.018956  # 1/CURV
+              obscuration:
+                type: ClearCircle
+                radius: 0.775
+              coordSys:
+                z: 0.08231  # DISZ
+        -
+          type: Lens
+          name: L2
+          medium: *silica
+          coordSys:
+            z: 0.494881  # cumsum of some DISZ, checked against global vertex coord
+          items:
+            -
+              type: RefractiveInterface
+              name: L2_entrance
+              surface:
+                type: Sum
+                items:
+                  -
+                    type: Sphere
+                    R: -48040.0  # 1/CURV
+                  -
+                    type: Zernike
+                    R_outer: 0.551
+                    coef:
+                      - -0.0
+                      -  8.408e-09
+                      -  1.927e-09
+                      -  1.502e-09
+                      - -4.473e-08
+                      -  2.731e-09
+                      -  6.184e-08
+                      -  1.834e-09
+                      -  2.354e-09
+                      - -3.440e-08
+                      - -1.255e-08
+                      -  5.409e-08
+                      -  7.787e-09
+                      - -3.49e-09
+                      - -1.172e-09
+                      - -4.626e-09
+                      -  4.564e-09
+                      -  3.556e-09
+                      -  3.987e-09
+                      -  5.803e-09
+                      - -2.950e-09
+                      -  2.986e-09
+                      -  4.575e-08
+                      - -9.143e-10
+                      - -5.526e-10
+                      - -4.372e-09
+                      - -5.158e-10
+                      -  1.471e-09
+                      -  1.916e-09
+              obscuration:
+                type: ClearCircle
+                radius: 0.551
+            -
+              type: RefractiveInterface
+              name: L2_exit
+              surface:
+                type: Asphere
+                R: 2.5291       # 1/CURV
+                conic: -1.57    # CONI
+                coefs: [0.0, -0.001656]  # PARM
+              obscuration:
+                type: ClearCircle
+                radius: 0.551
+              coordSys:
+                z: 0.03005
+        -
+          type: Lens
+          name: Filter
+          medium: *silica
+          coordSys:
+            # accumulated transforms
+            x: -1.7328056696161860e-04
+            y: -2.7620000000000005e-04
+            z: 8.7116838944881725e-01
+            rotY: -7.5049157835756176e-05
+          items:
+            -
+              type: RefractiveInterface
+              name: Filter_entrance
+              surface:
+                type: Sphere
+                R: 5.632  # 1/CURV
+                # Note: For r and i band, read Zernike coefficients from multi-config data.
+              obscuration:
+                type: ClearCircle
+                radius: 0.375
+            -
+              type: RefractiveInterface
+              name: Filter_exit
+              surface:
+                type: Sphere
+                R: 5.632  # 1/CRVT from multi-configuration
+              obscuration:
+                type: ClearCircle
+                radius: 0.375
+              coordSys:
+                z: 0.0144  # THIC from multi-configuration
+        -
+          type: Lens
+          name: L3
+          medium: *silica
+          coordSys:
+            x: -1.7867810238809937e-04
+            y: -2.7620000000000010e-04
+            z: 9.4308838924627658e-01
+            rotY: -7.5049157835756176e-05
+          items:
+            -
+              type: RefractiveInterface
+              name: L3_entrance
+              surface:
+                type: Quadric
+                R: 3.169       # 1/CURV
+                conic: -0.962  # CONI
+              obscuration:
+                type: ClearCircle
+                radius: 0.361
+            -
+              type: RefractiveInterface
+              name: L3_exit
+              surface:
+                type: Sphere
+                R: -13.36   # 1/CURV
+              obscuration:
+                type: ClearCircle
+                radius: 0.361
+              coordSys:
+                z: 0.06008  #DISZ
+        -
+          type: Detector
+          name: Detector
+          surface:
+            type: Plane
+          obscuration:
+            type: ClearCircle
+            radius: 0.4
+          coordSys:
+            # accumulated transforms
+            x: -1.8535755247836943e-04
+            y: -2.7619999999999988e-04
+            z: 1.0320893889956335e+00
+            rotX: -2.0064305269723316e-04
+            rotY: -1.3718287644542526e-04
+            rotZ: -2.7524791390826322e-08

--- a/batoid/data/LSST/v1000_camera_body.py
+++ b/batoid/data/LSST/v1000_camera_body.py
@@ -1,0 +1,34 @@
+import batoid
+import numpy as np
+
+for f in "ugrizy":
+    telescope = batoid.Optic.fromYaml(f"Rubin_v1000_{f}.yaml")
+    camera = telescope["LSSTCamera"]
+    cs = camera.coordSys.shiftLocal([0.0, 0.0, 0.1045])
+    rx, ry, rz = cs.euler()
+    print(f"------ {f} ------")
+    print(camera.coordSys)
+    print(camera.coordSys.shiftLocal([0.0, 0.0, 0.1045]))
+
+    print(
+f"""
+    -
+      type: Baffle
+      name: CameraBody
+      parent: LSSTCamera  # physically attached to camera; moves with it under rigid-body ops
+      surface:
+        type: Plane
+      obscuration:
+        type: ObscCircle
+        radius: 0.80469  # = 1.60938/2 m; camera body outer diameter
+      coordSys:
+        x: {cs.origin[0]}
+        y: {cs.origin[1]}
+        z: {cs.origin[2]}
+        rotX: {rx}
+        rotY: {ry}
+        rotZ: {rz}
+"""
+    )
+
+    print()

--- a/tests/test_CoordSys.py
+++ b/tests/test_CoordSys.py
@@ -377,6 +377,51 @@ def test_ne():
     all_obj_diff(objs)
 
 
+@timer
+def test_euler():
+    # Identity CoordSys should give zero angles
+    rx, ry, rz = batoid.CoordSys().euler()
+    np.testing.assert_allclose([rx, ry, rz], [0, 0, 0], atol=1e-15)
+
+    # Single-axis rotations: the other two angles should be zero
+    for angle in [0.1, -0.3, 1.2]:
+        rx, ry, rz = batoid.CoordSys(rot=batoid.RotX(angle)).euler()
+        np.testing.assert_allclose(rx, angle, atol=1e-15)
+        np.testing.assert_allclose([ry, rz], [0, 0], atol=1e-15)
+
+        rx, ry, rz = batoid.CoordSys(rot=batoid.RotY(angle)).euler()
+        np.testing.assert_allclose(ry, angle, atol=1e-15)
+        np.testing.assert_allclose([rx, rz], [0, 0], atol=1e-15)
+
+        rx, ry, rz = batoid.CoordSys(rot=batoid.RotZ(angle)).euler()
+        np.testing.assert_allclose(rz, angle, atol=1e-15)
+        np.testing.assert_allclose([rx, ry], [0, 0], atol=1e-15)
+
+    # Round-trip: random angles, avoid gimbal lock (|ry| < pi/2)
+    rng = np.random.default_rng(42)
+    for _ in range(50):
+        origin = rng.uniform(-1, 1, size=3)
+        # Keep ry well away from ±pi/2
+        rx0 = rng.uniform(-1.5, 1.5)
+        ry0 = rng.uniform(-1.4, 1.4)
+        rz0 = rng.uniform(-1.5, 1.5)
+        rot = batoid.RotX(rx0) @ batoid.RotY(ry0) @ batoid.RotZ(rz0)
+        cs = batoid.CoordSys(origin, rot)
+        rx1, ry1, rz1 = cs.euler()
+        np.testing.assert_allclose([rx1, ry1, rz1], [rx0, ry0, rz0], atol=1e-13)
+
+    # Round-trip consistency with parse_coordSys
+    from batoid.parse import parse_coordSys
+    for _ in range(20):
+        rx0 = rng.uniform(-0.01, 0.01)  # small angles as in real LSST YAMLs
+        ry0 = rng.uniform(-0.01, 0.01)
+        rz0 = rng.uniform(-0.01, 0.01)
+        cs1 = parse_coordSys({'rotX': rx0, 'rotY': ry0, 'rotZ': rz0})
+        rx1, ry1, rz1 = cs1.euler()
+        cs2 = parse_coordSys({'rotX': rx1, 'rotY': ry1, 'rotZ': rz1})
+        np.testing.assert_allclose(cs1.rot, cs2.rot, atol=1e-15)
+
+
 if __name__ == '__main__':
     test_rot_matrix()
     test_params()
@@ -385,3 +430,4 @@ if __name__ == '__main__':
     test_rotate()
     test_combinations()
     test_ne()
+    test_euler()


### PR DESCRIPTION
Adds Rubin_v1000_*.yaml.  These are essentially the same as v3.14, but with a couple small tweaks:
- Adds the CameraBody obscuration between M2 and M3.
- Adjusts M1 and M3 radii
- Adds the M1Baffle surface